### PR TITLE
Improve buffer operation in miniz_oxide inflate/deflate mod.rs

### DIFF
--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -119,13 +119,8 @@ fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i3
     // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
     let flags = create_comp_flags_from_zip_params(level.into(), window_bits, strategy);
     let mut compressor = CompressorOxide::new(flags);
-    let mut output = Vec::with_capacity(input.len() / 2);
-    // # Unsafe
-    // We trust compress to not read the uninitialized bytes.
-    unsafe {
-        let cap = output.capacity();
-        output.set_len(cap);
-    }
+    let mut output = vec![0;input.len() / 2];
+
     let mut in_pos = 0;
     let mut out_pos = 0;
     loop {
@@ -149,14 +144,7 @@ fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i3
                 // We need more space, so extend the vector.
                 if output.len().saturating_sub(out_pos) < 30 {
                     let current_len = output.len();
-                    output.reserve(current_len);
-
-                    // # Unsafe
-                    // We trust compress to not read the uninitialized bytes.
-                    unsafe {
-                        let cap = output.capacity();
-                        output.set_len(cap);
-                    }
+                    output.extend(&vec![0;current_len]);
                 }
             }
             // Not supposed to happen unless there is a bug.

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -71,15 +71,8 @@ pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 
 fn decompress_to_vec_inner(input: &[u8], flags: u32) -> Result<Vec<u8>, TINFLStatus> {
     let flags = flags | inflate_flags::TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
-    let mut ret = Vec::with_capacity(input.len() * 2);
+    let mut ret : Vec<u8> = vec![0;input.len() * 2];
 
-    // # Unsafe
-    // We trust decompress to not read the unitialized bytes as it's wrapped
-    // in a cursor that's position is set to the end of the initialized data.
-    unsafe {
-        let cap = ret.capacity();
-        ret.set_len(cap);
-    };
     let mut decomp = unsafe { DecompressorOxide::with_init_state_only() };
 
     let mut in_pos = 0;
@@ -103,14 +96,7 @@ fn decompress_to_vec_inner(input: &[u8], flags: u32) -> Result<Vec<u8>, TINFLSta
 
             TINFLStatus::HasMoreOutput => {
                 // We need more space so extend the buffer.
-                ret.reserve(out_pos);
-                // # Unsafe
-                // We trust decompress to not read the unitialized bytes as it's wrapped
-                // in a cursor that's position is set to the end of the initialized data.
-                unsafe {
-                    let cap = ret.capacity();
-                    ret.set_len(cap);
-                }
+                ret.extend(&vec![0;out_pos]);
             },
 
             _ => return Err(status),


### PR DESCRIPTION
Rust has a llvm backend and it automatically optimizes on such buffer operations. The performance benchmark results show that performance gained ~1%-~1.5% in this patch.