### PR TITLE
Gracefully handle type confusion of inflate_state and tdefl_compressor in mz_stream in C API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,10 @@ macro_rules! oxidize {
                     // Make sure we catch a potential panic, as
                     // this is called from C.
                     match catch_unwind(AssertUnwindSafe(|| {
-                        let mut stream_oxide = StreamOxide::new(&mut *stream).unwrap();
+                        let mut stream_oxide = match StreamOxide::new(&mut *stream) {
+                            Ok(stream_oxide) => stream_oxide,
+                            Err(e) => return e as c_int
+                        };
                         let status = $mz_func_oxide(&mut stream_oxide, $($arg_name),*);
                         *stream = stream_oxide.into_mz_stream();
                         as_c_return_code(status)
@@ -234,7 +237,11 @@ pub unsafe extern "C" fn mz_compress2(
                 ..Default::default()
             };
 
-            let mut stream_oxide = StreamOxide::new(&mut stream).unwrap();
+            let mut stream_oxide = match StreamOxide::new(&mut stream) {
+                Ok(stream_oxide) => stream_oxide,
+                Err(e) => return e as c_int
+            };
+
             as_c_return_code(mz_compress2_oxide(&mut stream_oxide, level, dest_len))
         },
     )
@@ -272,7 +279,11 @@ pub unsafe extern "C" fn mz_uncompress(
                 ..Default::default()
             };
 
-            let mut stream_oxide = StreamOxide::new(&mut stream).unwrap();
+            let mut stream_oxide = match StreamOxide::new(&mut stream) {
+                Ok(stream_oxide) => stream_oxide,
+                Err(e) => return e as c_int
+            };
+
             as_c_return_code(mz_uncompress2_oxide(&mut stream_oxide, dest_len))
         },
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ macro_rules! oxidize {
                     // Make sure we catch a potential panic, as
                     // this is called from C.
                     match catch_unwind(AssertUnwindSafe(|| {
-                        let mut stream_oxide = StreamOxide::new(&mut *stream);
+                        let mut stream_oxide = StreamOxide::new(&mut *stream).unwrap();
                         let status = $mz_func_oxide(&mut stream_oxide, $($arg_name),*);
                         *stream = stream_oxide.into_mz_stream();
                         as_c_return_code(status)
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn mz_compress2(
                 ..Default::default()
             };
 
-            let mut stream_oxide = StreamOxide::new(&mut stream);
+            let mut stream_oxide = StreamOxide::new(&mut stream).unwrap();
             as_c_return_code(mz_compress2_oxide(&mut stream_oxide, level, dest_len))
         },
     )
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn mz_uncompress(
                 ..Default::default()
             };
 
-            let mut stream_oxide = StreamOxide::new(&mut stream);
+            let mut stream_oxide = StreamOxide::new(&mut stream).unwrap();
             as_c_return_code(mz_uncompress2_oxide(&mut stream_oxide, dest_len))
         },
     )

--- a/src/lib_oxide.rs
+++ b/src/lib_oxide.rs
@@ -12,6 +12,7 @@ use miniz_oxide::inflate::TINFLStatus;
 use miniz_oxide::inflate::core::{TINFL_LZ_DICT_SIZE, inflate_flags, DecompressorOxide};
 
 use miniz_oxide::*;
+use miniz_oxide::deflate::core::{CompressorOxide};
 
 const MZ_DEFLATED: c_int = 8;
 const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
@@ -475,6 +476,17 @@ pub struct inflate_state {
     pub m_window_bits: c_int,
     pub m_dict: [u8; TINFL_LZ_DICT_SIZE],
     pub m_last_status: TINFLStatus,
+    // consistent with tdefl_compressor in case there is a type confusion
+    pub inner: Option<CompressorOxide>,
+}
+
+// There could be a type confusion problem when calling deflateEnd with inflate
+// stream buffer. Making inflate_state consistent with tdefl_compressor can
+// workaround this issue.
+impl inflate_state {
+    pub fn drop_inner(&mut self) {
+        self.inner = None;
+    }
 }
 
 pub fn mz_inflate_init_oxide(stream_oxide: &mut StreamOxide<inflate_state>) -> MZResult {

--- a/src/lib_oxide.rs
+++ b/src/lib_oxide.rs
@@ -231,11 +231,6 @@ pub struct StreamOxide<'io, ST: StateType> {
 
 impl<'io, ST: StateType> StreamOxide<'io, ST> {
     pub unsafe fn new(stream: &mut mz_stream) -> Result<Self, MZError> {
-        // XXX: When calling init function, the state is null. We cannot check it here.
-        // if stream.state.is_null() {
-        //     return Err(MZError::Stream);
-        // }
-
         if !stream.state.is_null() {
             let stream_type_slice: StreamType = ptr::read(stream.state as *const StreamType);
             if stream_type_slice != ST::get_stream_type() {

--- a/src/lib_oxide.rs
+++ b/src/lib_oxide.rs
@@ -466,6 +466,8 @@ pub fn mz_deflate_reset_oxide(stream_oxide: &mut StreamOxide<tdefl_compressor>) 
 #[repr(C)]
 #[allow(bad_style)]
 pub struct inflate_state {
+    // consistent with tdefl_compressor in case there is a type confusion
+    pub inner: Option<CompressorOxide>,
     pub m_decomp: DecompressorOxide,
 
     pub m_dict_ofs: c_uint,
@@ -476,8 +478,6 @@ pub struct inflate_state {
     pub m_window_bits: c_int,
     pub m_dict: [u8; TINFL_LZ_DICT_SIZE],
     pub m_last_status: TINFLStatus,
-    // consistent with tdefl_compressor in case there is a type confusion
-    pub inner: Option<CompressorOxide>,
 }
 
 // There could be a type confusion problem when calling deflateEnd with inflate

--- a/src/tdef.rs
+++ b/src/tdef.rs
@@ -4,6 +4,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use miniz_oxide::deflate::core::{compress, compress_to_output, create_comp_flags_from_zip_params,
                                  CompressorOxide, TDEFLFlush, TDEFLStatus};
+use lib_oxide::StreamType;
 
 /// Compression callback function type.
 pub type PutBufFuncPtrNotNull = unsafe extern "C" fn(
@@ -44,6 +45,7 @@ pub mod strategy {
 #[repr(C)]
 #[allow(bad_style)]
 pub struct tdefl_compressor {
+    pub stream_type: StreamType,
     pub inner: Option<CompressorOxide>,
     pub callback: Option<CallbackFunc>,
 }
@@ -51,6 +53,7 @@ pub struct tdefl_compressor {
 impl tdefl_compressor {
     pub(crate) fn new(flags: u32) -> Self {
         tdefl_compressor {
+            stream_type: StreamType::Deflate,
             inner: Some(CompressorOxide::new(flags)),
             callback: None,
         }
@@ -58,6 +61,7 @@ impl tdefl_compressor {
 
     pub(crate) fn new_with_callback(flags: u32, func: CallbackFunc) -> Self {
         tdefl_compressor {
+            stream_type: StreamType::Deflate,
             inner: Some(CompressorOxide::new(flags)),
             callback: Some(func),
         }
@@ -178,6 +182,7 @@ pub unsafe extern "C" fn tdefl_compress_buffer(
 pub unsafe extern "C" fn tdefl_allocate() -> *mut tdefl_compressor {
     Box::into_raw(Box::<tdefl_compressor>::new(
         tdefl_compressor {
+            stream_type: StreamType::Deflate,
             inner: None,
             callback: None,
         }


### PR DESCRIPTION
The `inflate_state` and `tdefl_compressor` state struct are not consistent.  This will cause a type confusion issue when calling `deflateEnd` with the inflate stream buffer using the C API, resulting a "double free" crash. The zlib library doesn't have this problem because when calling the `deflateEnd`, it knows the type of the state buffer. Instead, miniz_oxide's C API has to cast this buffer to Rust's type and lose its original type.

This PR crates a bogus field to make the `inflate_state ` strut same as `tdefl_compressor` to work around this memory safety issue.