### PR TITLE
The allocator_api feature should be conditionally enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ language:
   - cpp
 compiler:
   - gcc
-rust: nightly
+rust:
+  - stable
+  - nightly
 before_install:
   - sudo apt-get update
   - sudo apt-get install valgrind

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(allocator_api)]
+#![cfg_attr(any(feature = "libc_stub", all(target_arch = "wasm32", not(target_os = "emscripten"))), feature(allocator_api))]
 
 extern crate crc;
 #[cfg(not(any(feature = "libc_stub", all(target_arch = "wasm32", not(target_os = "emscripten")))))]


### PR DESCRIPTION
It should only be enabled for the same config that the libc stub is
enabled (wasm32-unknown-unknown target or the libc_stub feature).

This fixes builds on stable rust