### PR TITLE
Remove allocator_api feature in order to compile on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(allocator_api)]
-
 extern crate crc;
 #[cfg(not(any(feature = "libc_stub", all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 extern crate libc;


### PR DESCRIPTION
The allocator_api feature is now stable.