### PR TITLE
use crc32fast crate for SIMD accelerated CRC32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "miniz_oxide_c_api"
 
 [dependencies]
 libc = "0.2.22"
-crc = "1.0.0"
+crc32fast = "1.2.0"
 miniz_oxide = { path = "miniz_oxide", version = "0.2.1" }
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate crc;
+extern crate crc32fast;
 #[cfg(not(any(feature = "libc_stub", all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 extern crate libc;
 #[cfg(any(feature = "libc_stub", all(target_arch = "wasm32", not(target_os = "emscripten"))))]
@@ -49,7 +49,6 @@ extern crate miniz_oxide;
 
 use std::{cmp, ptr, slice};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use crc::{Hasher32, crc32};
 
 use libc::{c_int, c_uint, c_ulong, c_void, size_t};
 
@@ -81,9 +80,9 @@ pub use tdef::flush_modes::*;
 pub use tdef::strategy::*;
 
 pub fn mz_crc32_oxide(crc32: c_uint, data: &[u8]) -> c_uint {
-    let mut digest = crc32::Digest::new_with_initial(crc32::IEEE, crc32);
-    digest.write(data);
-    digest.sum32()
+    let mut digest = crc32fast::Hasher::new_with_initial(crc32);
+    digest.update(data);
+    digest.finalize()
 }
 
 pub const MZ_DEFLATED: c_int = 8;


### PR DESCRIPTION
The [`crc32fast`](https://crates.io/crates/crc32fast) crate provides optimized CRC32 IEEE implementations that are between 7x (non-simd) and 35x (simd) faster compared to the `crc` crate.

This should help speed up consumers using the `mz_crc32` function by a good margin.