### PR TITLE
Fix buffer overflow bug in deflate::core::BitBuffer::flush

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -572,7 +572,7 @@ impl BitBuffer {
         let pos = output.inner.position() as usize;
         { // isolation to please borrow checker
             let inner = &mut (*output.inner.get_mut())[pos..pos+8];
-            inner.copy_from_slice(&self.bit_buffer.to_le_bytes());
+            inner.copy_from_slice(&u64_to_le_bytes(self.bit_buffer));
         }
         output.inner.seek(
             SeekFrom::Current((self.bits_in >> 3) as i64),
@@ -581,6 +581,13 @@ impl BitBuffer {
         self.bits_in &= 7;
         Ok(())
     }
+}
+
+#[inline]
+/// Copy of u64::to_le_bytes() that is only available starting at Rust 1.32,
+/// while we want to support older Rust versions
+fn u64_to_le_bytes(num: u64) -> [u8; 8] {
+    unsafe { mem::transmute(num.to_le()) }
 }
 
 /// A struct containing data about huffman codes and symbol frequencies.


### PR DESCRIPTION
The problem is that this function does not check that there is enough space to fit a `u64`, it only checks that the starting position for the write is in bounds.

I have tried adding `assert!(pos.checked_add(8).unwrap() <= output.inner.get_ref().len());` before the unsafe part, but that regressed performance exactly as much as the fully safe version, so I went for the fully safe code.