### PR TITLE
Use standard rust allocator in C API, save state type in mz_stream

### DIFF
--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -205,7 +205,10 @@ impl DecompressorOxide {
     /// Create a new decompressor with only the state field initialized.
     ///
     /// This is how it's created in miniz. Unsafe due to uninitialized values.
+    /// Usage is not recommended.
     #[inline]
+    #[deprecated(since = "0.2.2",
+                 note="Will be removed as the safety of using this is hard to verify.")]
     pub unsafe fn with_init_state_only() -> DecompressorOxide {
         let mut decomp: DecompressorOxide = mem::uninitialized();
         decomp.state = core::State::Start;
@@ -1785,7 +1788,7 @@ mod test {
     }
 
     fn check_result(input: &[u8], expected_status: TINFLStatus, expected_state: State, zlib: bool) {
-        let mut r = unsafe { DecompressorOxide::with_init_state_only() };
+        let mut r = DecompressorOxide::default();
         let mut output_buf = vec![0; 1024 * 32];
         let mut out_cursor = Cursor::new(output_buf.as_mut_slice());
         let flags = if zlib {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod libc {
 
     use std::alloc::{alloc as rust_alloc, realloc as rust_realloc, dealloc as rust_dealloc, Layout};
     use std::mem;
-    use std::ptr::NonNull;
 
     pub type c_void = u8;
     pub type c_int = i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,16 @@ macro_rules! oxidize {
                     // Make sure we catch a potential panic, as
                     // this is called from C.
                     match catch_unwind(AssertUnwindSafe(|| {
-                        let mut stream_oxide = StreamOxide::new(&mut *stream);
-                        let status = $mz_func_oxide(&mut stream_oxide, $($arg_name),*);
-                        *stream = stream_oxide.into_mz_stream();
-                        as_c_return_code(status)
+                        // Do some checks to see if the stream object has the right type.
+                        match StreamOxide::try_new(stream) {
+                            Ok(mut stream_oxide) => {
+                                let status = $mz_func_oxide(&mut stream_oxide, $($arg_name),*);
+                                *stream = stream_oxide.into_mz_stream();
+                                as_c_return_code(status) }
+                            Err(e) => {
+                                e as c_int
+                            }
+                        }
                     })) {
                         Ok(res) => res,
                         Err(_) => {
@@ -162,16 +168,12 @@ macro_rules! oxidize {
     };
 }
 
-oxidize!(mz_deflateInit2, mz_deflate_init2_oxide;
-         level: c_int, method: c_int, window_bits: c_int, mem_level: c_int, strategy: c_int);
 oxidize!(mz_deflate, mz_deflate_oxide;
          flush: c_int);
 oxidize!(mz_deflateEnd, mz_deflate_end_oxide;);
 oxidize!(mz_deflateReset, mz_deflate_reset_oxide;);
 
 
-oxidize!(mz_inflateInit2, mz_inflate_init2_oxide;
-         window_bits: c_int);
 oxidize!(mz_inflate, mz_inflate_oxide;
          flush: c_int);
 oxidize!(mz_inflateEnd, mz_inflate_end_oxide;);
@@ -186,6 +188,64 @@ pub unsafe extern "C" fn mz_deflateInit(stream: *mut mz_stream, level: c_int) ->
         9,
         CompressionStrategy::Default as c_int,
     )
+}
+
+pub unsafe extern "C" fn mz_deflateInit2(stream: *mut mz_stream, level: c_int, method: c_int,
+                                         window_bits: c_int, mem_level: c_int, strategy: c_int)
+                                         -> c_int {
+    match stream.as_mut() {
+        None => MZError::Stream as c_int,
+        Some(stream) => {
+            stream.data_type = StateTypeEnum::Deflate;
+            // Make sure we catch a potential panic, as
+            // this is called from C.
+            match catch_unwind(AssertUnwindSafe(|| {
+                match StreamOxide::try_new(stream) {
+                    Ok(mut stream_oxide) => {
+                        let status = mz_deflate_init2_oxide(&mut stream_oxide,level, method,
+                                                            window_bits, mem_level, strategy);
+                        *stream = stream_oxide.into_mz_stream();
+                        as_c_return_code(status) }
+                    Err(e) => {
+                        e as c_int
+                    }
+                }
+            })) {
+                Ok(res) => res,
+                Err(_) => {
+                    println!("FATAL ERROR: Caught panic!");
+                    MZError::Stream as c_int},
+            }
+        }
+    }
+}
+
+pub unsafe extern "C" fn mz_inflateInit2(stream: *mut mz_stream, window_bits: c_int)
+                                         -> c_int {
+    match stream.as_mut() {
+        None => MZError::Stream as c_int,
+        Some(stream) => {
+            stream.data_type = StateTypeEnum::Inflate;
+            // Make sure we catch a potential panic, as
+            // this is called from C.
+            match catch_unwind(AssertUnwindSafe(|| {
+                match StreamOxide::try_new(stream) {
+                    Ok(mut stream_oxide) => {
+                        let status = mz_inflate_init2_oxide(&mut stream_oxide,window_bits);
+                        *stream = stream_oxide.into_mz_stream();
+                        as_c_return_code(status) }
+                    Err(e) => {
+                        e as c_int
+                    }
+                }
+            })) {
+                Ok(res) => res,
+                Err(_) => {
+                    println!("FATAL ERROR: Caught panic!");
+                    MZError::Stream as c_int},
+            }
+        }
+    }
 }
 
 pub unsafe extern "C" fn mz_compress(
@@ -222,6 +282,7 @@ pub unsafe extern "C" fn mz_compress2(
                 avail_in: source_len as c_uint,
                 next_out: dest,
                 avail_out: (*dest_len) as c_uint,
+                data_type: StateTypeEnum::Deflate,
                 ..Default::default()
             };
 
@@ -260,9 +321,11 @@ pub unsafe extern "C" fn mz_uncompress(
                 avail_in: source_len as c_uint,
                 next_out: dest,
                 avail_out: (*dest_len) as c_uint,
+                data_type: StateTypeEnum::Inflate,
                 ..Default::default()
             };
 
+            // We don't expect this to fail since we supply the stream ourselves.
             let mut stream_oxide = StreamOxide::new(&mut stream);
             as_c_return_code(mz_uncompress2_oxide(&mut stream_oxide, dest_len))
         },

--- a/src/tinfl.rs
+++ b/src/tinfl.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn tinfl_decompress_mem_to_heap(
     // We're not using a Vec for the buffer here to make sure the buffer is allocated and freed by
     // the same allocator.
 
-    let mut decomp = tinfl_decompressor::with_init_state_only();
+    let mut decomp = tinfl_decompressor::default();
     // Pointer to the buffer to place the decompressed data into.
     let mut p_buf: *mut c_void = ::miniz_def_alloc_func(ptr::null_mut(), MIN_BUFFER_CAPACITY, 1);
     // Capacity of the current output buffer.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,5 @@
 extern crate miniz_oxide;
+extern crate miniz_oxide_c_api;
 
 use std::io::Read;
 
@@ -48,4 +49,59 @@ fn roundtrip_level_1() {
     );
     let dec = decompress_to_vec(enc.as_slice()).unwrap();
     assert!(data == dec);
+}
+
+#[test]
+fn c_api() {
+    use miniz_oxide_c_api::lib_oxide::mz_stream;
+    use miniz_oxide_c_api::{mz_deflateInit, mz_deflate, mz_deflateEnd,
+                            mz_inflateInit, mz_inflate, mz_inflateEnd};
+    use miniz_oxide::{MZStatus, MZError};
+    let mut data = get_test_data();
+    let mut compressed = vec![0; data.len() + 50];
+    let compressed_size;
+    let decompressed_size;
+    unsafe {
+        let mut stream = mz_stream {
+            next_in: data.as_mut_ptr(),
+            avail_in: data.len() as u32,
+            next_out: compressed.as_mut_ptr(),
+            avail_out: compressed.len() as u32,
+            ..Default::default()
+        };
+
+        assert_eq!(mz_deflateInit(&mut stream, 1), MZStatus::Ok as libc::c_int);
+        assert_eq!(mz_deflate(&mut stream, 4), MZStatus::StreamEnd as libc::c_int);
+        assert_eq!(mz_deflateEnd(&mut stream), MZStatus::Ok as libc::c_int);
+        compressed_size = stream.total_out;
+
+        assert_eq!(mz_inflate(&mut stream, 4), MZError::Param as libc::c_int);
+        assert_eq!(mz_inflateEnd(&mut stream), MZError::Param as libc::c_int);
+    }
+
+    assert!(compressed_size <= compressed.len() as u64);
+
+    let mut decompressed = vec![0;data.len()];
+
+    unsafe {
+        let mut stream = mz_stream {
+            next_in: compressed.as_mut_ptr(),
+            avail_in: compressed_size as u32,
+            next_out: decompressed.as_mut_ptr(),
+            avail_out: decompressed.len() as u32,
+            ..Default::default()
+        };
+
+        assert_eq!(mz_inflateInit(&mut stream),MZStatus::Ok as libc::c_int);
+        assert_eq!(mz_inflate(&mut stream, 4),MZStatus::StreamEnd as libc::c_int);
+        assert_eq!(mz_inflateEnd(&mut stream),MZStatus::Ok as libc::c_int);
+
+        decompressed_size = stream.total_out;
+
+        // This should fail as the stream is an inflate stream!
+        assert_eq!(mz_deflate(&mut stream, 4), MZError::Param as libc::c_int);
+        assert_eq!(mz_deflateEnd(&mut stream), MZError::Param as libc::c_int);
+    }
+
+    assert_eq!(data[..], decompressed[0..decompressed_size as usize]);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -70,16 +70,16 @@ fn c_api() {
             ..Default::default()
         };
 
-        assert_eq!(mz_deflateInit(&mut stream, 1), MZStatus::Ok as libc::c_int);
-        assert_eq!(mz_deflate(&mut stream, 4), MZStatus::StreamEnd as libc::c_int);
-        assert_eq!(mz_deflateEnd(&mut stream), MZStatus::Ok as libc::c_int);
+        assert_eq!(mz_deflateInit(&mut stream, 1), MZStatus::Ok as i32);
+        assert_eq!(mz_deflate(&mut stream, 4), MZStatus::StreamEnd as i32);
+        assert_eq!(mz_deflateEnd(&mut stream), MZStatus::Ok as i32);
         compressed_size = stream.total_out;
 
-        assert_eq!(mz_inflate(&mut stream, 4), MZError::Param as libc::c_int);
-        assert_eq!(mz_inflateEnd(&mut stream), MZError::Param as libc::c_int);
+        assert_eq!(mz_inflate(&mut stream, 4), MZError::Param as i32);
+        assert_eq!(mz_inflateEnd(&mut stream), MZError::Param as i32);
     }
 
-    assert!(compressed_size <= compressed.len() as u64);
+    assert!(compressed_size as usize <= compressed.len());
 
     let mut decompressed = vec![0;data.len()];
 
@@ -92,15 +92,15 @@ fn c_api() {
             ..Default::default()
         };
 
-        assert_eq!(mz_inflateInit(&mut stream),MZStatus::Ok as libc::c_int);
-        assert_eq!(mz_inflate(&mut stream, 4),MZStatus::StreamEnd as libc::c_int);
-        assert_eq!(mz_inflateEnd(&mut stream),MZStatus::Ok as libc::c_int);
+        assert_eq!(mz_inflateInit(&mut stream),MZStatus::Ok as i32);
+        assert_eq!(mz_inflate(&mut stream, 4),MZStatus::StreamEnd as i32);
+        assert_eq!(mz_inflateEnd(&mut stream),MZStatus::Ok as i32);
 
         decompressed_size = stream.total_out;
 
         // This should fail as the stream is an inflate stream!
-        assert_eq!(mz_deflate(&mut stream, 4), MZError::Param as libc::c_int);
-        assert_eq!(mz_deflateEnd(&mut stream), MZError::Param as libc::c_int);
+        assert_eq!(mz_deflate(&mut stream, 4), MZError::Param as i32);
+        assert_eq!(mz_deflateEnd(&mut stream), MZError::Param as i32);
     }
 
     assert_eq!(data[..], decompressed[0..decompressed_size as usize]);


### PR DESCRIPTION
Replacement for #36

Putting this as a PR to test with CI etc..

Still needs some more cleanup but can do more on that later.