### PR TITLE
Avoid unnecessary copying by resizing instead of extending vectors

### DIFF
--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -141,10 +141,9 @@ fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i3
                 break;
             }
             TDEFLStatus::Okay => {
-                // We need more space, so extend the vector.
+                // We need more space, so resize the vector.
                 if output.len().saturating_sub(out_pos) < 30 {
-                    let current_len = output.len();
-                    output.extend(&vec![0;current_len]);
+                    output.resize(output.len() * 2, 0)
                 }
             }
             // Not supposed to happen unless there is a bug.

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -95,8 +95,8 @@ fn decompress_to_vec_inner(input: &[u8], flags: u32) -> Result<Vec<u8>, TINFLSta
             },
 
             TINFLStatus::HasMoreOutput => {
-                // We need more space so extend the buffer.
-                ret.extend(&vec![0;out_pos]);
+                // We need more space so resize the buffer.
+                ret.resize(ret.len() + out_pos, 0);
             },
 
             _ => return Err(status),


### PR DESCRIPTION
This saves time needed for copying zeroes and makes decoding 15% faster in my tests. The impact on encoding is smaller but there is also a measurable speedup.