### PR TITLE
Forbid unsafe code in the core crate

### DIFF
--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -21,6 +21,8 @@
 //!
 //! ```
 
+#![forbid(unsafe_code)]
+
 extern crate adler32;
 
 pub mod deflate;


### PR DESCRIPTION
Now that the core crate is 100% safe code while still being faster than the C version, it seems like a good idea to add `#![forbid(unsafe_code)]` annotation to keep it that way.

This annotation makes the compiler reject any unsafe blocks in the crate as long as it's present. This discourages people from trying to add unsafe blocks back in unless they're absolutely necessary. This is also picked up as a signal by some of the tooling, e.g. [cargo-geiger](https://github.com/anderejd/cargo-geiger).