### PR TITLE
Flag `miniz_oxide` as a `#![no_std]` library

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -17,4 +17,4 @@ exclude = ["benches/*", "tests/*"]
 name = "miniz_oxide"
 
 [dependencies]
-adler32 = "1.0.4"
+adler32 = { version = "1.0.4", default-features = false }

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -17,4 +17,15 @@ exclude = ["benches/*", "tests/*"]
 name = "miniz_oxide"
 
 [dependencies]
-adler32 = { version = "1.0.4", default-features = false }
+adler32 = { version = "1.1.0", default-features = false }
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
+compiler_builtins = { version = '0.1.2', optional = true }
+
+[features]
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler32/rustc-dep-of-std']

--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -1,5 +1,8 @@
 //! This module contains functionality for compression.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod buffer;
 pub mod core;
 pub mod stream;
@@ -119,7 +122,7 @@ fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i3
     // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
     let flags = create_comp_flags_from_zip_params(level.into(), window_bits, strategy);
     let mut compressor = CompressorOxide::new(flags);
-    let mut output = vec![0; std::cmp::max(input.len() / 2, 2)];
+    let mut output = vec![0; ::core::cmp::max(input.len() / 2, 2)];
 
     let mut in_pos = 0;
     let mut out_pos = 0;
@@ -157,6 +160,7 @@ fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i3
 mod test {
     use super::{compress_to_vec, compress_to_vec_inner, CompressionStrategy};
     use crate::inflate::decompress_to_vec;
+    use std::vec;
 
     /// Test deflate example.
     ///

--- a/miniz_oxide/src/deflate/stream.rs
+++ b/miniz_oxide/src/deflate/stream.rs
@@ -3,7 +3,7 @@
 //! As of now this is mainly inteded for use to build a higher-level wrapper.
 //!
 //! There is no DeflateState as the needed state is contained in the compressor struct itself.
-use std::convert::{AsMut, AsRef};
+use core::convert::{AsMut, AsRef};
 
 use crate::deflate::core::{compress, CompressorOxide, TDEFLFlush, TDEFLStatus};
 use crate::{MZError, MZFlush, MZStatus, StreamResult};
@@ -100,6 +100,9 @@ mod test {
     use crate::deflate::CompressorOxide;
     use crate::inflate::decompress_to_vec_zlib;
     use crate::{MZFlush, MZStatus};
+    use std::prelude::v1::*;
+    use std::vec;
+
     #[test]
     fn test_state() {
         let data = b"Hello zlib!";

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -1,7 +1,9 @@
 //! This module contains functionality for decompression.
 
-use std::io::Cursor;
-use std::usize;
+use ::core::usize;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub mod core;
 mod output_buffer;
@@ -79,13 +81,10 @@ fn decompress_to_vec_inner(input: &[u8], flags: u32) -> Result<Vec<u8>, TINFLSta
     let mut in_pos = 0;
     let mut out_pos = 0;
     loop {
-        let (status, in_consumed, out_consumed) = {
-            // Wrap the whole output slice so we know we have enough of the
-            // decompressed data for matches.
-            let mut c = Cursor::new(ret.as_mut_slice());
-            c.set_position(out_pos as u64);
-            decompress(&mut decomp, &input[in_pos..], &mut c, flags)
-        };
+        // Wrap the whole output slice so we know we have enough of the
+        // decompressed data for matches.
+        let (status, in_consumed, out_consumed) =
+            decompress(&mut decomp, &input[in_pos..], &mut ret, out_pos, flags);
         in_pos += in_consumed;
         out_pos += out_consumed;
 

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -21,9 +21,14 @@
 //!
 //! ```
 
+#![allow(warnings)]
 #![forbid(unsafe_code)]
+#![no_std]
 
-extern crate adler32;
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 pub mod deflate;
 pub mod inflate;
@@ -145,13 +150,13 @@ impl StreamResult {
     }
 }
 
-impl std::convert::From<StreamResult> for MZResult {
+impl core::convert::From<StreamResult> for MZResult {
     fn from(res: StreamResult) -> Self {
         res.status
     }
 }
 
-impl std::convert::From<&StreamResult> for MZResult {
+impl core::convert::From<&StreamResult> for MZResult {
     fn from(res: &StreamResult) -> Self {
         res.status
     }

--- a/miniz_oxide/tests/test.rs
+++ b/miniz_oxide/tests/test.rs
@@ -96,7 +96,6 @@ fn zlib_header_level() {
 #[test]
 fn need_more_input_has_more_output_at_same_time() {
     use miniz_oxide::inflate::core;
-    use std::io::Cursor;
 
     let input = get_test_file_data("tests/test_data/numbers.deflate");
     let data = get_test_file_data("tests/test_data/numbers.txt");
@@ -106,11 +105,10 @@ fn need_more_input_has_more_output_at_same_time() {
         decomp.init();
 
         let mut output = [0; core::TINFL_LZ_DICT_SIZE];
-        let mut output_cursor = Cursor::new(&mut output[..]);
         let flags = core::inflate_flags::TINFL_FLAG_HAS_MORE_INPUT;
 
         let (status, in_consumed, out_consumed) =
-            core::decompress(&mut decomp, input, &mut output_cursor, flags);
+            core::decompress(&mut decomp, input, &mut output, 0, flags);
 
         let input_empty = in_consumed == input.len();
         let output_full = out_consumed == output.len();


### PR DESCRIPTION
This commit conversion the `miniz_oxide` crate to a `#![no_std]`
library, and is as a result a breaking change for the library. Currently
the only dependency on the `std` crate is the `std::io::Cursor` type,
which is pretty easily replaced with a `usize` parameter in a few
locations.

The goal of this commit is to eventually enable this library to be
included into the standard library itself. Dependencies of the standard
library can't depend on the standard library as well! The reason for
including this in the standard library is that the `backtrace` crate
wants to decompress DWARF information in executables, which can be
compressed with zlib.