### PR TITLE
Switch from adler32 to adler crate

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["benches/*", "tests/*"]
 name = "miniz_oxide"
 
 [dependencies]
-adler32 = { version = "1.1.0", default-features = false }
+adler = { version = "0.2.1", default-features = false }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
@@ -28,4 +28,4 @@ compiler_builtins = { version = '0.1.2', optional = true }
 [features]
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler32/rustc-dep-of-std']
+rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler/rustc-dep-of-std']

--- a/miniz_oxide/src/shared.rs
+++ b/miniz_oxide/src/shared.rs
@@ -1,4 +1,4 @@
-use adler32::RollingAdler32;
+use adler::Adler32;
 
 #[doc(hidden)]
 pub const MZ_ADLER32_INIT: u32 = 1;
@@ -12,7 +12,7 @@ pub const HUFFMAN_LENGTH_ORDER: [u8; 19] = [
 
 #[doc(hidden)]
 pub fn update_adler32(adler: u32, data: &[u8]) -> u32 {
-    let mut hash = RollingAdler32::from_value(adler);
-    hash.update_buffer(data);
-    hash.hash()
+    let mut hash = Adler32::from_checksum(adler);
+    hash.write_slice(data);
+    hash.checksum()
 }


### PR DESCRIPTION
The adler crate is my clean-room reimplementation of Adler-32. The adler32 crate uses the Zlib license, while adler uses MIT/Apache-2.0 (or 0BSD), which makes integration into the standard library easier.

adler is also faster in the benchmarks I've made so far, although that isn't reflected in the miniz_oxide benchmarks (which in fact seemed to slightly regress on my system, but that might just be noise).