### PR TITLE
Add an optional feature for 1.34.2 backwards compatibility

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -29,3 +29,5 @@ compiler_builtins = { version = '0.1.2', optional = true }
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler/rustc-dep-of-std']
+# Use std instead of alloc. This should only be used for backwards compatibility.
+no_extern_crate_alloc = []

--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains functionality for compression.
 
-use alloc::vec;
-use alloc::vec::Vec;
+use crate::alloc::vec;
+use crate::alloc::vec::Vec;
 
 mod buffer;
 pub mod core;

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -1,9 +1,9 @@
 //! This module contains functionality for decompression.
 
 use ::core::usize;
-use alloc::boxed::Box;
-use alloc::vec;
-use alloc::vec::Vec;
+use crate::alloc::boxed::Box;
+use crate::alloc::vec;
+use crate::alloc::vec::Vec;
 
 pub mod core;
 mod output_buffer;

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -1,7 +1,7 @@
 //! Extra streaming decompression functionality.
 //!
 //! As of now this is mainly inteded for use to build a higher-level wrapper.
-use alloc::boxed::Box;
+use crate::alloc::boxed::Box;
 use core::{cmp, mem};
 
 use crate::inflate::core::{decompress, inflate_flags, DecompressorOxide, TINFL_LZ_DICT_SIZE};

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -23,9 +23,12 @@
 
 #![allow(warnings)]
 #![forbid(unsafe_code)]
-#![no_std]
+#![cfg_attr(not(feature = "no_extern_crate_alloc"), no_std)]
 
+#[cfg(not(feature = "no_extern_crate_alloc"))]
 extern crate alloc;
+#[cfg(feature = "no_extern_crate_alloc")]
+use std as alloc;
 
 #[cfg(test)]
 extern crate std;


### PR DESCRIPTION
The readme states that the crate is compatible with `1.34`, however this is no longer true due to relying on `extern crate alloc` which was stabilized in `1.36`. Since `alloc` is just a subset of `std` we can restore this compatibility via an optional feature, disabled by default and fully opt-in.

## Alternatives
* Add a features to disable all `alloc`-dependent items. This isn't really feasible with the current design which relies on `Box` and `Vec` internally.
* Don't do this. Then `image` might not profit from potential bugfixes until `0.24` :)

@alexcrichton Would this be fine and compatible with `std` inclusion, by not activating the feature there?