### PR TITLE
Automatic alloc detection

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -12,9 +12,13 @@ documentation = "https://docs.rs/miniz_oxide"
 description = "DEFLATE compression and decompression library rewritten in Rust based on miniz"
 edition = "2018"
 exclude = ["benches/*", "tests/*"]
+build = "build.rs"
 
 [lib]
 name = "miniz_oxide"
+
+[build-dependencies]
+autocfg = "1.0"
 
 [dependencies]
 adler = { version = "0.2.1", default-features = false }
@@ -29,5 +33,3 @@ compiler_builtins = { version = '0.1.2', optional = true }
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler/rustc-dep-of-std']
-# Use std instead of alloc. This should only be used for backwards compatibility.
-no_extern_crate_alloc = []

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -33,3 +33,5 @@ compiler_builtins = { version = '0.1.2', optional = true }
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler/rustc-dep-of-std']
+# This feature has no effect (See Frommi/miniz_oxide#95)
+no_extern_crate_alloc = []

--- a/miniz_oxide/build.rs
+++ b/miniz_oxide/build.rs
@@ -1,0 +1,5 @@
+use autocfg;
+
+fn main() {
+    autocfg::new().emit_sysroot_crate("alloc");
+}

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -23,11 +23,11 @@
 
 #![allow(warnings)]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "no_extern_crate_alloc"), no_std)]
+#![cfg_attr(has_alloc, no_std)]
 
-#[cfg(not(feature = "no_extern_crate_alloc"))]
+#[cfg(has_alloc)]
 extern crate alloc;
-#[cfg(feature = "no_extern_crate_alloc")]
+#[cfg(not(has_alloc))]
 use std as alloc;
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #94 

Uses `autocfg` to detect the availability of the `alloc` crate, removing the need for a feature. This avoids forcing libraries to proxy the feature through, or awkward extra dependencies on `miniz_oxide` to force the feature to be enabled.

I don't actually know any way this could break semver. The `no_extern_crate_alloc` won't use `alloc`<1.36, but they're all going to be rexported in `std` anyway. Either way, `0.4.1` is only ~10 days old