### PR TITLE
Add missing pub to FullReset's data format

### DIFF
--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -44,7 +44,7 @@ impl ResetPolicy for ZeroReset {
 /// Full reset of the state, including zeroing memory.
 ///
 /// Requires to provide new data format.
-pub struct FullReset(DataFormat);
+pub struct FullReset(pub DataFormat);
 
 impl ResetPolicy for FullReset {
     #[inline]


### PR DESCRIPTION
This is my oversight as `FullReset` cannot be constructed with private ctor