### PR TITLE
Add forbid unsafe code to build

### DIFF
--- a/miniz_oxide/build.rs
+++ b/miniz_oxide/build.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 use autocfg;
 
 fn main() {


### PR DESCRIPTION
This is because of a geiger issue
https://github.com/rust-secure-code/cargo-geiger/issues/82