### PR TITLE
Bump adler to a 1.0 version

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -21,7 +21,7 @@ name = "miniz_oxide"
 autocfg = "1.0"
 
 [dependencies]
-adler = { version = "0.2.3", default-features = false }
+adler = { version = "1.0", default-features = false }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.


### PR DESCRIPTION
There should be no perceivable differences from this crate's PoV and 1.0 version inspires more confidence :smile: 

Differences: https://github.com/jonas-schievink/adler/compare/v0.2.3...v1.0.1