### PR TITLE
Attempt to add some documentation to external API's.

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -257,7 +257,7 @@ impl TDEFLFlush {
 pub enum TDEFLStatus {
     /// Usage error.
     ///
-    /// This indicates that either the [`CompressorOxide`] experience a previous error, or the
+    /// This indicates that either the [`CompressorOxide`] experienced a previous error, or the
     /// stream has already been [`TDEFLFlush::Finish`]'d.
     BadParam = -2,
 

--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -222,6 +222,8 @@ pub enum TDEFLFlush {
     Full = 3,
 
     /// Try to flush everything and end the deflate stream.
+    ///
+    /// On success this will yield a [`TDEFLStatus::Done`] return status.
     Finish = 4,
 }
 
@@ -249,13 +251,27 @@ impl TDEFLFlush {
     }
 }
 
-/// Return status codes.
+/// Return status of compression.
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TDEFLStatus {
+    /// Usage error.
+    ///
+    /// This indicates that either the [`CompressorOxide`] experience a previous error, or the
+    /// stream has already been [`TDEFLFlush::Finish`]'d.
     BadParam = -2,
+
+    /// Error putting data into output buffer.
+    ///
+    /// This usually indicates a too-small buffer.
     PutBufFailed = -1,
+
+    /// Compression succeeded normally.
     Okay = 0,
+
+    /// Compression succeeded and the deflate stream was ended.
+    ///
+    /// This is the result of calling compression with [`TDEFLFlush::Finish`].
     Done = 1,
 }
 

--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -2176,7 +2176,7 @@ fn flush_output_buffer(c: &mut CallbackOxide, p: &mut ParamsOxide) -> (TDEFLStat
 ///
 /// The value of `flush` determines if the compressor should attempt to flush all output
 /// and alternatively try to finish the stream.
-/// Should be `TDeflflush::Finish` on the final call.
+/// Should be [`TDEFLFlush::Finish`] on the final call.
 ///
 /// # Returns
 /// Returns a tuple containing the current status of the compressor, the current position

--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -209,15 +209,19 @@ pub enum CompressionStrategy {
 /// A list of deflate flush types.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TDEFLFlush {
-    /// Compress as much as there is space for, and then return
-    /// waiting for more input.
+    /// Normal operation.
+    ///
+    /// Compress as much as there is space for, and then return waiting for more input.
     None = 0,
-    /// Try to flush the current data and output an empty raw block.
+
+    /// Try to flush all the current data and output an empty raw block.
     Sync = 2,
-    /// Same as sync, but reset the dictionary so that the following data does not depend
-    /// on previous data.
+
+    /// Same as [`Sync`][Self::Sync], but reset the dictionary so that the following data does not
+    /// depend on previous data.
     Full = 3,
-    /// Try to flush everything and end the stream.
+
+    /// Try to flush everything and end the deflate stream.
     Finish = 4,
 }
 

--- a/miniz_oxide/src/deflate/stream.rs
+++ b/miniz_oxide/src/deflate/stream.rs
@@ -1,6 +1,6 @@
 //! Extra streaming compression functionality.
 //!
-//! As of now this is mainly inteded for use to build a higher-level wrapper.
+//! As of now this is mainly intended for use to build a higher-level wrapper.
 //!
 //! There is no DeflateState as the needed state is contained in the compressor struct itself.
 use core::convert::{AsMut, AsRef};

--- a/miniz_oxide/src/deflate/stream.rs
+++ b/miniz_oxide/src/deflate/stream.rs
@@ -12,11 +12,14 @@ use crate::{MZError, MZFlush, MZStatus, StreamResult};
 ///
 /// # Errors
 ///
-/// Returns `MZError::Buf` If the size of the `output` slice is empty or no progress was made due to
-/// lack of expected input data or called after the compression was finished without
-/// MZFlush::Finish.
+/// Returns [`MZError::Buf`] If the size of the `output` slice is empty or no progress was made due
+/// to lack of expected input data, or if called without [`MZFlush::Finish`] after the compression
+/// was already finished.
 ///
-/// Returns `MZError::Param` if the compressor parameters are set wrong.
+/// Returns [`MZError::Param`] if the compressor parameters are set wrong.
+///
+/// Returns [`MZError::Stream`] when lower-level decompressor returns a
+/// [`TDEFLStatus::PutBufFailed`]; may not actually be possible.
 pub fn deflate(
     compressor: &mut CompressorOxide,
     input: &[u8],

--- a/miniz_oxide/src/deflate/stream.rs
+++ b/miniz_oxide/src/deflate/stream.rs
@@ -8,7 +8,7 @@ use core::convert::{AsMut, AsRef};
 use crate::deflate::core::{compress, CompressorOxide, TDEFLFlush, TDEFLStatus};
 use crate::{MZError, MZFlush, MZStatus, StreamResult};
 
-/// Try to compress from input to output with the given Compressor
+/// Try to compress from input to output with the given [`CompressorOxide`].
 ///
 /// # Errors
 ///

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1032,7 +1032,7 @@ fn decompress_fast(
 /// Flags to indicate settings and status to the decompression function.
 /// * The [`TINFL_FLAG_HAS_MORE_INPUT`] has to be specified if more compressed data is to be provided
 /// in a subsequent call to this function.
-/// * See the the [`inflate_flags`](inflate_flags/index.html) module for details on other flags.
+/// * See the the [`inflate_flags`] module for details on other flags.
 ///
 /// # Returns
 /// returns a tuple containing the status of the compressor, the number of input bytes read, and the

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1014,10 +1014,10 @@ fn decompress_fast(
 /// `in_buf` is a reference to the compressed data that is to be decompressed. The decompressor will
 /// start at the first byte of this buffer.
 ///
-/// `out` is a mutable cursor into the buffer that will store the decompressed data, and that
+/// `out` is a reference to the buffer that will store the decompressed data, and that
 /// stores previously decompressed data if any.
-/// * The position of the output cursor indicates where in the output buffer slice writing should
-/// start.
+///
+/// * The offset given by `out_pos` indicates where in the output buffer slice writing should start.
 /// * If [`TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF`] is not set, the output buffer is used in a
 /// wrapping manner, and it's size is required to be a power of 2.
 /// * The decompression function normally needs access to 32KiB of the previously decompressed data

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1006,7 +1006,7 @@ fn decompress_fast(
 }
 
 /// Main decompression function. Keeps decompressing data from `in_buf` until the `in_buf` is
-/// empty, `out_cur` is full, the end of the deflate stream is hit, or there is an error in the
+/// empty, `out` is full, the end of the deflate stream is hit, or there is an error in the
 /// deflate stream.
 ///
 /// # Arguments
@@ -1014,7 +1014,7 @@ fn decompress_fast(
 /// `in_buf` is a reference to the compressed data that is to be decompressed. The decompressor will
 /// start at the first byte of this buffer.
 ///
-/// `out_cur` is a mutable cursor into the buffer that will store the decompressed data, and that
+/// `out` is a mutable cursor into the buffer that will store the decompressed data, and that
 /// stores previously decompressed data if any.
 /// * The position of the output cursor indicates where in the output buffer slice writing should
 /// start.
@@ -1036,8 +1036,8 @@ fn decompress_fast(
 ///
 /// # Returns
 /// returns a tuple containing the status of the compressor, the number of input bytes read, and the
-/// number of bytes output to `out_cur`.
-/// Updates the position of `out_cur` to point to the next free spot in the output buffer.
+/// number of bytes output to `out`.
+/// Updates the position of `out` to point to the next free spot in the output buffer.
 ///
 /// This function shouldn't panic pending any bugs.
 pub fn decompress(

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1018,7 +1018,7 @@ fn decompress_fast(
 /// stores previously decompressed data if any.
 /// * The position of the output cursor indicates where in the output buffer slice writing should
 /// start.
-/// * If TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF is not set, the output buffer is used in a
+/// * If [`TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF`] is not set, the output buffer is used in a
 /// wrapping manner, and it's size is required to be a power of 2.
 /// * The decompression function normally needs access to 32KiB of the previously decompressed data
 ///(or to the beginning of the decompressed data if less than 32KiB has been decompressed.)
@@ -1030,7 +1030,7 @@ fn decompress_fast(
 ///
 /// `flags`
 /// Flags to indicate settings and status to the decompression function.
-/// * The `TINFL_FLAG_HAS_MORE_INPUT` has to be specified if more compressed data is to be provided
+/// * The [`TINFL_FLAG_HAS_MORE_INPUT`] has to be specified if more compressed data is to be provided
 /// in a subsequent call to this function.
 /// * See the the [`inflate_flags`](inflate_flags/index.html) module for details on other flags.
 ///

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1034,6 +1034,8 @@ fn decompress_fast(
 ///
 /// # Arguments
 ///
+/// `r` is a [`DecompressorOxide`] struct with the state of this stream.
+///
 /// `in_buf` is a reference to the compressed data that is to be decompressed. The decompressor will
 /// start at the first byte of this buffer.
 ///

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1035,9 +1035,9 @@ fn decompress_fast(
 /// * See the the [`inflate_flags`] module for details on other flags.
 ///
 /// # Returns
-/// returns a tuple containing the status of the compressor, the number of input bytes read, and the
+///
+/// Returns a tuple containing the status of the compressor, the number of input bytes read, and the
 /// number of bytes output to `out`.
-/// Updates the position of `out` to point to the next free spot in the output buffer.
 ///
 /// This function shouldn't panic pending any bugs.
 pub fn decompress(

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -102,23 +102,46 @@ const LITLEN_TABLE: usize = 0;
 const DIST_TABLE: usize = 1;
 const HUFFLEN_TABLE: usize = 2;
 
+/// Flags to [`decompress()`] to control how inflation works.
+///
+/// These define bits for a bitmask argument.
 pub mod inflate_flags {
     /// Should we try to parse a zlib header?
+    ///
+    /// If unset, [`decompress()`] will expect an RFC1951 deflate stream.  If set, it will expect an
+    /// RFC1950 zlib wrapper around the deflate stream.
     pub const TINFL_FLAG_PARSE_ZLIB_HEADER: u32 = 1;
-    /// There is more input that hasn't been given to the decompressor yet.
+
+    /// There will be more input that hasn't been given to the decompressor yet.
+    ///
+    /// This is useful when you want to decompress what you have so far,
+    /// even if you know there is probably more input that hasn't gotten here yet (_e.g._, over a
+    /// network connection).  When [`decompress()`][super::decompress] reaches the end of the input
+    /// without finding the end of the compressed stream, it will return
+    /// [`TINFLStatus::NeedsMoreInput`][super::TINFLStatus::NeedsMoreInput] if this is set,
+    /// indicating that you should get more data before calling again.  If not set, it will return
+    /// [`TINFLStatus::FailedCannotMakeProgress`][super::TINFLStatus::FailedCannotMakeProgress]
+    /// suggesting the stream is corrupt, since you claimed it was all there.
     pub const TINFL_FLAG_HAS_MORE_INPUT: u32 = 2;
+
     /// The output buffer should not wrap around.
     pub const TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF: u32 = 4;
-    /// Should we calculate the adler32 checksum of the output data even if we're not inflating a
-    /// zlib stream?
+
+    /// Calculate the adler32 checksum of the output data even if we're not inflating a zlib stream.
     ///
-    /// NOTE: Enable/disabling this between calls to decompress will result in an incorect checksum.
+    /// If [`TINFL_FLAG_IGNORE_ADLER32`] is specified, it will override this.
+    ///
+    /// NOTE: Enabling/disabling this between calls to decompress will result in an incorect
+    /// checksum.
     pub const TINFL_FLAG_COMPUTE_ADLER32: u32 = 8;
-    /// Should we ignore adler32 checksum even if we are inflating a zlib stream.
-    /// Overrides TINFL_FLAG_COMPUTE_ADLER32 if both are enabled.
+
+    /// Ignore adler32 checksum even if we are inflating a zlib stream.
+    ///
+    /// Overrides [`TINFL_FLAG_COMPUTE_ADLER32`] if both are enabled.
     ///
     /// NOTE: This flag does not exist in miniz as it does not support this and is a
     /// custom addition for miniz_oxide.
+    ///
     /// NOTE: Should not be changed from enabled to disabled after decompression has started,
     /// this will result in checksum failure (outside the unlikely event where the checksum happens
     /// to match anyway).

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1028,8 +1028,7 @@ fn decompress_fast(
 /// and thus allows a smaller output buffer. The window size can be specified in the zlib
 /// header structure, however, the header data should not be relied on to be correct.
 ///
-/// `flags`
-/// Flags to indicate settings and status to the decompression function.
+/// `flags` indicates settings and status to the decompression function.
 /// * The [`TINFL_FLAG_HAS_MORE_INPUT`] has to be specified if more compressed data is to be provided
 /// in a subsequent call to this function.
 /// * See the the [`inflate_flags`] module for details on other flags.

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -80,7 +80,7 @@ impl TINFLStatus {
 
 /// Decompress the deflate-encoded data in `input` to a vector.
 ///
-/// Returns a status and an integer representing where the decompressor failed on failure.
+/// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
 pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(input, 0, usize::max_value())
@@ -88,7 +88,7 @@ pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 
 /// Decompress the deflate-encoded data (with a zlib wrapper) in `input` to a vector.
 ///
-/// Returns a status and an integer representing where the decompressor failed on failure.
+/// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
 pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(
@@ -102,7 +102,7 @@ pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 /// The vector is grown to at most `max_size` bytes; if the data does not fit in that size,
 /// [`TINFLStatus::HasMoreOutput`] error is returned.
 ///
-/// Returns a status and an integer representing where the decompressor failed on failure.
+/// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
 pub fn decompress_to_vec_with_limit(input: &[u8], max_size: usize) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(input, 0, max_size)
@@ -112,7 +112,7 @@ pub fn decompress_to_vec_with_limit(input: &[u8], max_size: usize) -> Result<Vec
 /// The vector is grown to at most `max_size` bytes; if the data does not fit in that size,
 /// [`TINFLStatus::HasMoreOutput`] error is returned.
 ///
-/// Returns a status and an integer representing where the decompressor failed on failure.
+/// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
 pub fn decompress_to_vec_zlib_with_limit(
     input: &[u8],
@@ -121,6 +121,9 @@ pub fn decompress_to_vec_zlib_with_limit(
     decompress_to_vec_inner(input, inflate_flags::TINFL_FLAG_PARSE_ZLIB_HEADER, max_size)
 }
 
+/// Backend of various to-[`Vec`] decompressions.
+///
+/// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 fn decompress_to_vec_inner(
     input: &[u8],
     flags: u32,

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -23,19 +23,34 @@ const TINFL_STATUS_HAS_MORE_OUTPUT: i32 = 2;
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TINFLStatus {
-    /// More input data was expected, but the caller indicated that there was more data, so the
+    /// More input data was expected, but the caller indicated that there was no more data, so the
     /// input stream is likely truncated.
+    ///
+    /// This can't happen if you have provided the
+    /// [`TINFL_FLAG_HAS_MORE_INPUT`][core::inflate_flags::TINFL_FLAG_HAS_MORE_INPUT] flag to the
+    /// decompression.  By setting that flag, you indicate more input exists but is not provided,
+    /// and so reaching the end of the input data without finding the end of the compressed stream
+    /// would instead return a [`NeedsMoreInput`][Self::NeedsMoreInput] status.
     FailedCannotMakeProgress = TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS as i8,
-    /// One or more of the input parameters were invalid.
+    /// The output buffer is an invalid size; consider the `flags` parameter.
     BadParam = TINFL_STATUS_BAD_PARAM as i8,
     /// The decompression went fine, but the adler32 checksum did not match the one
     /// provided in the header.
     Adler32Mismatch = TINFL_STATUS_ADLER32_MISMATCH as i8,
     /// Failed to decompress due to invalid data.
     Failed = TINFL_STATUS_FAILED as i8,
-    /// Finished decomression without issues.
+    /// Finished decompression without issues.
+    ///
+    /// This indicates the end of the compressed stream has been reached.
     Done = TINFL_STATUS_DONE as i8,
     /// The decompressor needs more input data to continue decompressing.
+    ///
+    /// This occurs when there's no more consumable input, but the end of the stream hasn't been
+    /// reached, and you have supplied the
+    /// [`TINFL_FLAG_HAS_MORE_INPUT`][core::inflate_flags::TINFL_FLAG_HAS_MORE_INPUT] flag to the
+    /// decompressor.  Had you not supplied that flag (which would mean you were asserting that you
+    /// believed all the data was available) you would have gotten a
+    /// [`FailedCannotMakeProcess`][Self::FailedCannotMakeProgress] instead.
     NeedsMoreInput = TINFL_STATUS_NEEDS_MORE_INPUT as i8,
     /// There is still pending data that didn't fit in the output buffer.
     HasMoreOutput = TINFL_STATUS_HAS_MORE_OUTPUT as i8,

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -100,7 +100,7 @@ pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 
 /// Decompress the deflate-encoded data in `input` to a vector.
 /// The vector is grown to at most `max_size` bytes; if the data does not fit in that size,
-/// `TINFLStatus::HasMoreOutput` error is returned.
+/// [`TINFLStatus::HasMoreOutput`] error is returned.
 ///
 /// Returns a status and an integer representing where the decompressor failed on failure.
 #[inline]
@@ -110,7 +110,7 @@ pub fn decompress_to_vec_with_limit(input: &[u8], max_size: usize) -> Result<Vec
 
 /// Decompress the deflate-encoded data (with a zlib wrapper) in `input` to a vector.
 /// The vector is grown to at most `max_size` bytes; if the data does not fit in that size,
-/// `TINFLStatus::HasMoreOutput` error is returned.
+/// [`TINFLStatus::HasMoreOutput`] error is returned.
 ///
 /// Returns a status and an integer representing where the decompressor failed on failure.
 #[inline]

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -32,17 +32,22 @@ pub enum TINFLStatus {
     /// and so reaching the end of the input data without finding the end of the compressed stream
     /// would instead return a [`NeedsMoreInput`][Self::NeedsMoreInput] status.
     FailedCannotMakeProgress = TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS as i8,
+
     /// The output buffer is an invalid size; consider the `flags` parameter.
     BadParam = TINFL_STATUS_BAD_PARAM as i8,
+
     /// The decompression went fine, but the adler32 checksum did not match the one
     /// provided in the header.
     Adler32Mismatch = TINFL_STATUS_ADLER32_MISMATCH as i8,
+
     /// Failed to decompress due to invalid data.
     Failed = TINFL_STATUS_FAILED as i8,
+
     /// Finished decompression without issues.
     ///
     /// This indicates the end of the compressed stream has been reached.
     Done = TINFL_STATUS_DONE as i8,
+
     /// The decompressor needs more input data to continue decompressing.
     ///
     /// This occurs when there's no more consumable input, but the end of the stream hasn't been
@@ -52,6 +57,7 @@ pub enum TINFLStatus {
     /// believed all the data was available) you would have gotten a
     /// [`FailedCannotMakeProcess`][Self::FailedCannotMakeProgress] instead.
     NeedsMoreInput = TINFL_STATUS_NEEDS_MORE_INPUT as i8,
+
     /// There is still pending data that didn't fit in the output buffer.
     HasMoreOutput = TINFL_STATUS_HAS_MORE_OUTPUT as i8,
 }

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -1,6 +1,6 @@
 //! Extra streaming decompression functionality.
 //!
-//! As of now this is mainly inteded for use to build a higher-level wrapper.
+//! As of now this is mainly intended for use to build a higher-level wrapper.
 use crate::alloc::boxed::Box;
 use core::{cmp, mem};
 

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -157,6 +157,15 @@ impl InflateState {
 
 /// Try to decompress from `input` to `output` with the given [`InflateState`]
 ///
+/// # `flush`
+///
+/// Generally, the various [`MZFlush`] flags have meaning only on the compression side.  They can be
+/// supplied here, but the only one that has any semantic meaning is [`MZFlush::Finish`], which is a
+/// signal that the stream is expected to finish, and failing to do so is an error.  It isn't
+/// necessary to specify it when the stream ends; you'll still get returned a
+/// [`MZStatus::StreamEnd`] anyway.  Other values either have no effect or cause errors.  It's
+/// likely that you'll almost always just want to use [`MZFlush::None`].
+///
 /// # Errors
 ///
 /// Returns [`MZError::Buf`] if the size of the `output` slice is empty or no progress was made due

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -155,15 +155,20 @@ impl InflateState {
     }
 }
 
-/// Try to decompress from `input` to `output` with the given `InflateState`
+/// Try to decompress from `input` to `output` with the given [`InflateState`]
 ///
 /// # Errors
 ///
-/// Returns `MZError::Buf` If the size of the `output` slice is empty or no progress was made due to
-/// lack of expected input data or called after the decompression was
-/// finished without MZFlush::Finish.
+/// Returns [`MZError::Buf`] if the size of the `output` slice is empty or no progress was made due
+/// to lack of expected input data, or if called with [`MZFlush::Finish`] and input wasn't all
+/// consumed.
 ///
-/// Returns `MZError::Param` if the compressor parameters are set wrong.
+/// Returns [`MZError::Data`] if this or a a previous call failed with an error return from
+/// [`TINFLStatus`]; probably indicates corrupted data.
+///
+/// Returns [`MZError::Stream`] when called with [`MZFlush::Full`] (meaningless on
+/// decompression), or when called without [`MZFlush::Finish`] after an earlier call with
+/// [`MZFlush::Finish`] has been made.
 pub fn inflate(
     state: &mut InflateState,
     input: &[u8],

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -51,7 +51,8 @@ pub enum MZFlush {
     Sync = 2,
     /// Same as [`Sync`], but resets the compression dictionary so that further compressed
     /// data does not depend on data compressed before the flush.
-    /// Has no use in decompression.
+    ///
+    /// Has no use in decompression, and is an error to supply in that case.
     Full = 3,
     /// Attempt to flush the remaining data and end the stream.
     Finish = 4,
@@ -75,24 +76,68 @@ impl MZFlush {
 }
 
 /// A list of miniz successful status codes.
+///
+/// These are emitted as the [`Ok`] side of a [`MZResult`] in the [`StreamResult`] returned from
+/// [`deflate::stream::deflate()`] or [`inflate::stream::inflate()`].
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MZStatus {
+    /// Operation succeeded.
+    ///
+    /// Some data was decompressed or compressed; see the byte counters in the [`StreamResult`] for
+    /// details.
     Ok = 0,
+
+    /// Operation succeeded and end of deflate stream was found.
+    ///
+    /// X-ref [`TINFLStatus::Done`][inflate::TINFLStatus::Done] or
+    /// [`TDEFLStatus::Done`][deflate::core::TDEFLStatus::Done] for `inflate` or `deflate`
+    /// respectively.
     StreamEnd = 1,
+
+    /// Unused
     NeedDict = 2,
 }
 
 /// A list of miniz failed status codes.
+///
+/// These are emitted as the [`Err`] side of a [`MZResult`] in the [`StreamResult`] returned from
+/// [`deflate::stream::deflate()`] or [`inflate::stream::inflate()`].
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MZError {
+    /// Unused
     ErrNo = -1,
+
+    /// General stream error.
+    ///
+    /// See [`inflate::stream::inflate()`] docs for details of how it can occur there.
+    ///
+    /// See [`deflate::stream::deflate()`] docs for how it can in principle occur there, though it's
+    /// believed impossible in practice.
     Stream = -2,
+
+    /// Error in inflation; see [`inflate::stream::inflate()`] for details.
+    ///
+    /// Not returned from [`deflate::stream::deflate()`].
     Data = -3,
+
+    /// Unused
     Mem = -4,
+
+    /// Buffer-related error.
+    ///
+    /// See the docs of [`deflate::stream::deflate()`] or [`inflate::stream::inflate()`] for details
+    /// of when it would trigger in the one you're using.
     Buf = -5,
+
+    /// Unused
     Version = -6,
+
+    /// Bad parameters.
+    ///
+    /// This can be returned from [`deflate::stream::deflate()`] in the case of bad parameters.  See
+    /// [`TDEFLStatus::BadParam`][deflate::core::TDEFLStatus::BadParam].
     Param = -10_000,
 }
 

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::shared::{MZ_ADLER32_INIT, MZ_DEFAULT_WINDOW_BITS};
 
 /// A list of flush types.
 ///
-/// See [http://www.bolet.org/~pornin/deflate-flush.html] for more in-depth info.
+/// See <http://www.bolet.org/~pornin/deflate-flush.html> for more in-depth info.
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MZFlush {
@@ -44,12 +44,12 @@ pub enum MZFlush {
     /// Used when more input data is expected.
     None = 0,
     /// Zlib partial flush.
-    /// Currently treated as `Sync`.
+    /// Currently treated as [`Sync`].
     Partial = 1,
     /// Finish compressing the currently buffered data, and output an empty raw block.
     /// Has no use in decompression.
     Sync = 2,
-    /// Same as `Sync`, but resets the compression dictionary so that further compressed
+    /// Same as [`Sync`], but resets the compression dictionary so that further compressed
     /// data does not depend on data compressed before the flush.
     /// Has no use in decompression.
     Full = 3,


### PR DESCRIPTION
This attempts to add some documentation onto the core and streaming in/deflate functions, their controlling arguments, and their various return values.  Details were found via inspection of code (and occasional reference to the miniz C code), and are believed reasonable as far as they go, but I can't guarantee I have a particularly good understanding of everything.