### PR TITLE
Fix readme example

### DIFF
--- a/miniz_oxide/Readme.md
+++ b/miniz_oxide/Readme.md
@@ -15,16 +15,20 @@ miniz_oxide can optionally be made to use a simd-accelerated version of adler32 
 Simple compression/decompression:
 ```rust
 
-extern crate miniz_oxide;
-
-use miniz_oxide::inflate::decompress_to_vec;
 use miniz_oxide::deflate::compress_to_vec;
+use miniz_oxide::inflate::decompress_to_vec;
 
 fn roundtrip(data: &[u8]) {
-    # compress the input
+    // Compress the input
     let compressed = compress_to_vec(data, 6);
-    # decompress the compressed input
-    let decompressed = decompress_to_vec(decompressed.as_slice()).expect("Failed to decompress!");
+    // Decompress the compressed input
+    let decompressed = decompress_to_vec(compressed.as_slice()).expect("Failed to decompress!");
+    // Check roundtrip succeeded
+    assert_eq!(data, decompressed);
+}
+
+fn main() {
+    roundtrip("Hello, world!".as_bytes());
 }
 
 ```


### PR DESCRIPTION
I fixed the readme example. The comments used hashes instead of slashes. Furthermore, the decompressed variable was used for input to the decompression function instead of the compressed variable.

I also added a main function and a check so that the code can be run without any modifications.