### PR TITLE
fix some clippy lints

### DIFF
--- a/miniz_oxide/src/deflate/stream.rs
+++ b/miniz_oxide/src/deflate/stream.rs
@@ -3,7 +3,6 @@
 //! As of now this is mainly intended for use to build a higher-level wrapper.
 //!
 //! There is no DeflateState as the needed state is contained in the compressor struct itself.
-use core::convert::{AsMut, AsRef};
 
 use crate::deflate::core::{compress, CompressorOxide, TDEFLFlush, TDEFLStatus};
 use crate::{MZError, MZFlush, MZStatus, StreamResult};
@@ -45,8 +44,8 @@ pub fn deflate(
     let mut bytes_written = 0;
     let mut bytes_consumed = 0;
 
-    let mut next_in = input.as_ref();
-    let mut next_out = output.as_mut();
+    let mut next_in = input;
+    let mut next_out = output;
 
     let status = loop {
         let in_bytes;

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -875,7 +875,7 @@ fn apply_match(
 /// and already improves decompression speed a fair bit.
 fn decompress_fast(
     r: &mut DecompressorOxide,
-    mut in_iter: &mut slice::Iter<u8>,
+    in_iter: &mut slice::Iter<u8>,
     out_buf: &mut OutputBuffer,
     flags: u32,
     local_vars: &mut LocalVars,
@@ -900,7 +900,7 @@ fn decompress_fast(
                 break 'o TINFLStatus::Done;
             }
 
-            fill_bit_buffer(&mut l, &mut in_iter);
+            fill_bit_buffer(&mut l, in_iter);
 
             if let Some((symbol, code_len)) = r.tables[LITLEN_TABLE].lookup(l.bit_buf) {
                 l.counter = symbol as u32;
@@ -914,7 +914,7 @@ fn decompress_fast(
                     // If we have a 32-bit buffer we need to read another two bytes now
                     // to have enough bits to keep going.
                     if cfg!(not(target_pointer_width = "64")) {
-                        fill_bit_buffer(&mut l, &mut in_iter);
+                        fill_bit_buffer(&mut l, in_iter);
                     }
 
                     if let Some((symbol, code_len)) = r.tables[LITLEN_TABLE].lookup(l.bit_buf) {
@@ -964,7 +964,7 @@ fn decompress_fast(
             // Length and distance codes have a number of extra bits depending on
             // the base, which together with the base gives us the exact value.
 
-            fill_bit_buffer(&mut l, &mut in_iter);
+            fill_bit_buffer(&mut l, in_iter);
             if l.num_extra != 0 {
                 let extra_bits = l.bit_buf & ((1 << l.num_extra) - 1);
                 l.bit_buf >>= l.num_extra;
@@ -975,7 +975,7 @@ fn decompress_fast(
             // We found a length code, so a distance code should follow.
 
             if cfg!(not(target_pointer_width = "64")) {
-                fill_bit_buffer(&mut l, &mut in_iter);
+                fill_bit_buffer(&mut l, in_iter);
             }
 
             if let Some((mut symbol, code_len)) = r.tables[DIST_TABLE].lookup(l.bit_buf) {
@@ -995,7 +995,7 @@ fn decompress_fast(
             }
 
             if l.num_extra != 0 {
-                fill_bit_buffer(&mut l, &mut in_iter);
+                fill_bit_buffer(&mut l, in_iter);
                 let extra_bits = l.bit_buf & ((1 << l.num_extra) - 1);
                 l.bit_buf >>= l.num_extra;
                 l.num_bits -= l.num_extra;

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -225,25 +225,25 @@ mod test {
         decompress_slice_iter_to_slice, decompress_to_vec_zlib, decompress_to_vec_zlib_with_limit,
         TINFLStatus,
     };
-    const encoded: [u8; 20] = [
+    const ENCODED: [u8; 20] = [
         120, 156, 243, 72, 205, 201, 201, 215, 81, 168, 202, 201, 76, 82, 4, 0, 27, 101, 4, 19,
     ];
 
     #[test]
     fn decompress_vec() {
-        let res = decompress_to_vec_zlib(&encoded[..]).unwrap();
+        let res = decompress_to_vec_zlib(&ENCODED[..]).unwrap();
         assert_eq!(res.as_slice(), &b"Hello, zlib!"[..]);
     }
 
     #[test]
     fn decompress_vec_with_high_limit() {
-        let res = decompress_to_vec_zlib_with_limit(&encoded[..], 100_000).unwrap();
+        let res = decompress_to_vec_zlib_with_limit(&ENCODED[..], 100_000).unwrap();
         assert_eq!(res.as_slice(), &b"Hello, zlib!"[..]);
     }
 
     #[test]
     fn fail_to_decompress_with_limit() {
-        let res = decompress_to_vec_zlib_with_limit(&encoded[..], 8);
+        let res = decompress_to_vec_zlib_with_limit(&ENCODED[..], 8);
         match res {
             Err(TINFLStatus::HasMoreOutput) => (), // expected result
             _ => panic!("Decompression output size limit was not enforced"),
@@ -255,7 +255,7 @@ mod test {
         // one slice
         let mut out = [0_u8; 12_usize];
         let r =
-            decompress_slice_iter_to_slice(&mut out, Some(&encoded[..]).into_iter(), true, false);
+            decompress_slice_iter_to_slice(&mut out, Some(&ENCODED[..]).into_iter(), true, false);
         assert_eq!(r, Ok(12));
         assert_eq!(&out[..12], &b"Hello, zlib!"[..]);
 
@@ -266,14 +266,14 @@ mod test {
             // the adler32 data off from the last actual data.
             let mut out = [0_u8; 12_usize + 1];
             let r =
-                decompress_slice_iter_to_slice(&mut out, encoded.chunks(chunk_size), true, false);
+                decompress_slice_iter_to_slice(&mut out, ENCODED.chunks(chunk_size), true, false);
             assert_eq!(r, Ok(12));
             assert_eq!(&out[..12], &b"Hello, zlib!"[..]);
         }
 
         // output buffer too small
         let mut out = [0_u8; 3_usize];
-        let r = decompress_slice_iter_to_slice(&mut out, encoded.chunks(7), true, false);
+        let r = decompress_slice_iter_to_slice(&mut out, ENCODED.chunks(7), true, false);
         assert!(r.is_err());
     }
 }

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -104,9 +104,10 @@ impl InflateState {
     /// `data_format`: Determines whether the compressed data is assumed to wrapped with zlib
     /// metadata.
     pub fn new(data_format: DataFormat) -> InflateState {
-        let mut b = InflateState::default();
-        b.data_format = data_format;
-        b
+        InflateState {
+            data_format,
+            ..Default::default()
+        }
     }
 
     /// Create a new state on the heap.
@@ -355,7 +356,7 @@ fn inflate_loop(
 fn push_dict_out(state: &mut InflateState, next_out: &mut &mut [u8]) -> usize {
     let n = cmp::min(state.dict_avail as usize, next_out.len());
     (next_out[..n]).copy_from_slice(&state.dict[state.dict_ofs..state.dict_ofs + n]);
-    *next_out = &mut mem::replace(next_out, &mut [])[n..];
+    *next_out = &mut mem::take(next_out)[n..];
     state.dict_avail -= n;
     state.dict_ofs = (state.dict_ofs + (n)) & (TINFL_LZ_DICT_SIZE - 1);
     n

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -21,7 +21,6 @@
 //!
 //! ```
 
-#![allow(warnings)]
 #![forbid(unsafe_code)]
 #![no_std]
 


### PR DESCRIPTION
How did that `#[allow(warnings)]` stayed there for almost two years 😅 

Nothing fancy, just running clippy.