### PR TITLE
Allow for running without allocator (inflate-only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "miniz_oxide_c_api"
 [dependencies]
 libc = "0.2.22"
 crc32fast = "1.2.0"
-miniz_oxide = { path = "miniz_oxide", version = "0.5.0" }
+miniz_oxide = { path = "miniz_oxide", version = "0.6.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pure rust Rust replacement for the [miniz](https://github.com/richgel999/miniz) 
 This project is organized into a C API shell and a rust crate.
 The Rust crate is found in the [miniz_oxide subdirectory](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide).
 
-miniz_oxide 0.5.x Requires at least rust 1.40.0, 0.3.x requires at least rust 0.36.0.
+miniz_oxide 0.5.x and 0.6.x Requires at least rust 1.40.0, 0.3.x requires at least rust 0.36.0.
 
 For a friendlier streaming API using readers and writers, [flate2](https://crates.io/crates/flate2) can be used, which can use miniz_oxide as a rust-only back-end.
 

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniz_oxide"
 authors = ["Frommi <daniil.liferenko@gmail.com>", "oyvindln <oyvindln@users.noreply.github.com>"]
-version = "0.5.3"
+version = "0.6.0"
 license = "MIT OR Zlib OR Apache-2.0"
 readme = "Readme.md"
 keywords = ["zlib", "miniz", "deflate", "encoding"]

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -27,7 +27,8 @@ alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-all
 compiler_builtins = { version = '0.1.2', optional = true }
 
 [features]
-default = []
+default = ["with-alloc"]
+with-alloc = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/miniz_oxide/Readme.md
+++ b/miniz_oxide/Readme.md
@@ -3,9 +3,16 @@
 A fully safe, pure rust replacement for the [miniz](https://github.com/richgel999/miniz) DEFLATE/zlib encoder/decoder.
 The main intention of this crate is to be used as a back-end for the [flate2](https://github.com/alexcrichton/flate2-rs), but it can also be used on it's own. Using flate2 with the ```rust_backend``` feature provides an easy to use streaming API for miniz_oxide.
 
-The library is fully [no_std](https://docs.rust-embedded.org/book/intro/no-std.html), though it requires the use of the `alloc` and `collection` crates as it allocates memory.
+The library is fully [no_std](https://docs.rust-embedded.org/book/intro/no-std.html). By default, the `with-alloc` feature is enabled, which requires the use of the `alloc` and `collection` crates as it allocates memory.
 
-miniz_oxide 0.5.x Requires at least rust 1.40.0 0.3.x requires at least rust 0.36.0.
+Using the library with `default-features = false` removes the dependency on `alloc`
+and `collection` crates, making it suitable for systems without an allocator.
+Running without allocation reduces crate functionality:
+
+- The `deflate` module is removed complete
+- Some `inflate` functions which return a `Vec` are removed
+
+miniz_oxide 0.5.x and 0.6.x Requires at least rust 1.40.0 0.3.x requires at least rust 0.36.0.
 
 miniz_oxide features no use of unsafe code.
 

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -1,9 +1,7 @@
 //! This module contains functionality for decompression.
 
-use crate::alloc::boxed::Box;
-use crate::alloc::vec;
-use crate::alloc::vec::Vec;
-use ::core::cmp::min;
+#[cfg(feature = "with-alloc")]
+use crate::alloc::{boxed::Box, vec, vec::Vec};
 use ::core::usize;
 
 pub mod core;
@@ -82,6 +80,7 @@ impl TINFLStatus {
 ///
 /// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
+#[cfg(feature = "with-alloc")]
 pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(input, 0, usize::max_value())
 }
@@ -90,6 +89,7 @@ pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 ///
 /// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
+#[cfg(feature = "with-alloc")]
 pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(
         input,
@@ -104,6 +104,7 @@ pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, TINFLStatus> {
 ///
 /// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
+#[cfg(feature = "with-alloc")]
 pub fn decompress_to_vec_with_limit(input: &[u8], max_size: usize) -> Result<Vec<u8>, TINFLStatus> {
     decompress_to_vec_inner(input, 0, max_size)
 }
@@ -114,6 +115,7 @@ pub fn decompress_to_vec_with_limit(input: &[u8], max_size: usize) -> Result<Vec
 ///
 /// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
 #[inline]
+#[cfg(feature = "with-alloc")]
 pub fn decompress_to_vec_zlib_with_limit(
     input: &[u8],
     max_size: usize,
@@ -124,13 +126,14 @@ pub fn decompress_to_vec_zlib_with_limit(
 /// Backend of various to-[`Vec`] decompressions.
 ///
 /// Returns a tuple of the [`Vec`] of decompressed data and the [status result][TINFLStatus].
+#[cfg(feature = "with-alloc")]
 fn decompress_to_vec_inner(
     input: &[u8],
     flags: u32,
     max_output_size: usize,
 ) -> Result<Vec<u8>, TINFLStatus> {
     let flags = flags | inflate_flags::TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
-    let mut ret: Vec<u8> = vec![0; min(input.len().saturating_mul(2), max_output_size)];
+    let mut ret: Vec<u8> = vec![0; input.len().saturating_mul(2).min(max_output_size)];
 
     let mut decomp = Box::<DecompressorOxide>::default();
 

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -1,7 +1,7 @@
 //! Extra streaming decompression functionality.
 //!
 //! As of now this is mainly intended for use to build a higher-level wrapper.
-#[cfg(feature = "use-alloc")]
+#[cfg(feature = "with-alloc")]
 use crate::alloc::boxed::Box;
 use core::{cmp, mem};
 
@@ -116,7 +116,7 @@ impl InflateState {
     /// # Parameters
     /// `data_format`: Determines whether the compressed data is assumed to wrapped with zlib
     /// metadata.
-    #[cfg(feature = "use-alloc")]
+    #[cfg(feature = "with-alloc")]
     pub fn new_boxed(data_format: DataFormat) -> Box<InflateState> {
         let mut b: Box<InflateState> = Box::default();
         b.data_format = data_format;
@@ -138,7 +138,7 @@ impl InflateState {
     /// The decompressor does not support different window sizes. As such,
     /// any positive (>0) value will set the zlib header flag, while a negative one
     /// will not.
-    #[cfg(feature = "use-alloc")]
+    #[cfg(feature = "with-alloc")]
     pub fn new_boxed_with_window_bits(window_bits: i32) -> Box<InflateState> {
         let mut b: Box<InflateState> = Box::default();
         b.data_format = DataFormat::from_window_bits(window_bits);

--- a/miniz_oxide/src/inflate/stream.rs
+++ b/miniz_oxide/src/inflate/stream.rs
@@ -1,6 +1,7 @@
 //! Extra streaming decompression functionality.
 //!
 //! As of now this is mainly intended for use to build a higher-level wrapper.
+#[cfg(feature = "use-alloc")]
 use crate::alloc::boxed::Box;
 use core::{cmp, mem};
 
@@ -115,6 +116,7 @@ impl InflateState {
     /// # Parameters
     /// `data_format`: Determines whether the compressed data is assumed to wrapped with zlib
     /// metadata.
+    #[cfg(feature = "use-alloc")]
     pub fn new_boxed(data_format: DataFormat) -> Box<InflateState> {
         let mut b: Box<InflateState> = Box::default();
         b.data_format = data_format;
@@ -136,6 +138,7 @@ impl InflateState {
     /// The decompressor does not support different window sizes. As such,
     /// any positive (>0) value will set the zlib header flag, while a negative one
     /// will not.
+    #[cfg(feature = "use-alloc")]
     pub fn new_boxed_with_window_bits(window_bits: i32) -> Box<InflateState> {
         let mut b: Box<InflateState> = Box::default();
         b.data_format = DataFormat::from_window_bits(window_bits);

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -24,8 +24,10 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
+#[cfg(feature = "with-alloc")]
 extern crate alloc;
 
+#[cfg(feature = "with-alloc")]
 pub mod deflate;
 pub mod inflate;
 mod shared;
@@ -154,7 +156,7 @@ pub enum DataFormat {
 }
 
 impl DataFormat {
-    pub(crate) fn from_window_bits(window_bits: i32) -> DataFormat {
+    pub fn from_window_bits(window_bits: i32) -> DataFormat {
         if window_bits > 0 {
             DataFormat::Zlib
         } else {
@@ -162,7 +164,7 @@ impl DataFormat {
         }
     }
 
-    pub(crate) fn to_window_bits(self) -> i32 {
+    pub fn to_window_bits(self) -> i32 {
         match self {
             DataFormat::Zlib | DataFormat::ZLibIgnoreChecksum => shared::MZ_DEFAULT_WINDOW_BITS,
             DataFormat::Raw => -shared::MZ_DEFAULT_WINDOW_BITS,
@@ -186,7 +188,7 @@ pub struct StreamResult {
 
 impl StreamResult {
     #[inline]
-    pub(crate) const fn error(error: MZError) -> StreamResult {
+    pub const fn error(error: MZError) -> StreamResult {
         StreamResult {
             bytes_consumed: 0,
             bytes_written: 0,


### PR DESCRIPTION
This PR adds a `with-alloc` feature to `miniz_oxide`, which is turned on by default and enables `alloc`-dependent functionality when active.

This allows us to specify `default-features = false` and use the crate in a system _without_ an allocator!