### PR TITLE
impl Display for DecompressError

### DIFF
--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -87,6 +87,21 @@ pub struct DecompressError {
 }
 
 #[cfg(feature = "with-alloc")]
+impl alloc::fmt::Display for DecompressError {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.write_str(match self.status {
+            TINFLStatus::FailedCannotMakeProgress => "Truncated input stream",
+            TINFLStatus::BadParam => "Invalid output buffer size",
+            TINFLStatus::Adler32Mismatch => "Adler32 checksum mismatch",
+            TINFLStatus::Failed => "Invalid input data",
+            TINFLStatus::Done => unreachable!(),
+            TINFLStatus::NeedsMoreInput => "Truncated input stream",
+            TINFLStatus::HasMoreOutput => "Output size exceeded the specified limit",
+        })
+    }
+}
+
+#[cfg(feature = "with-alloc")]
 fn decompress_error(status: TINFLStatus, output: Vec<u8>) -> Result<Vec<u8>, DecompressError> {
     Err(DecompressError { status, output })
 }


### PR DESCRIPTION
I wanted to go ahead and implement #122, but `miniz_oxide` only has feature flags for `alloc` and not `std`, so `Display` is as far as I could get. This is still much better than nothing.