### PR TITLE
Remove #[inline(always)] from CompressorOxide::default()

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -517,7 +517,6 @@ impl CompressorOxide {
 impl Default for CompressorOxide {
     /// Initialize the compressor with a level of 4, zlib wrapper and
     /// the default strategy.
-    #[inline(always)]
     fn default() -> Self {
         CompressorOxide {
             lz: LZOxide::new(),


### PR DESCRIPTION
With #[inline(always)] the body of default() will be inlined into external crates but the body will still contain calls to the LZOxide::new(), ParamsOxide::new(DEFAULT_FLAGS), Box::default() and DictOxide::new(DEFAULT_FLAGS). This ends up causing a copy of the large LZOxide to end up on the stack when used with Box::default as seen in: https://github.com/rust-lang/rust/issues/101814