### PR TITLE
Fix for older version of Rust

### DIFF
--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -821,7 +821,12 @@ fn transfer(
     // special case that comes up surprisingly often. in the case that `source_pos`
     // is 1 less than `out_pos`, we can say that the entire range will be the same
     // value and optimize this to be a simple `memset`
-    if out_buf_size_mask == usize::MAX && source_pos.abs_diff(out_pos) == 1 && out_pos > source_pos {
+    let source_diff = if source_pos > out_pos {
+        source_pos - out_pos
+    } else {
+        out_pos - source_pos
+    };
+    if out_buf_size_mask == usize::MAX && source_diff == 1 && out_pos > source_pos {
         let init = out_slice[out_pos - 1];
         let end = (match_len >> 2) * 4 + out_pos;
 
@@ -830,7 +835,7 @@ fn transfer(
         source_pos = end - 1;
     // if the difference between `source_pos` and `out_pos` is greater than 3, we
     // can do slightly better than the naive case by copying everything at once
-    } else if out_buf_size_mask == usize::MAX && source_pos.abs_diff(out_pos) >= 4 && out_pos > source_pos {
+    } else if out_buf_size_mask == usize::MAX && source_diff >= 4 && out_pos > source_pos {
         for _ in 0..match_len >> 2 {
             out_slice.copy_within(source_pos..=source_pos + 3, out_pos);
             source_pos += 4;


### PR DESCRIPTION
abs_diff didn't become stable until Rust 1.60, however the README states that 0.6 of miniz_oxide has a MSRV of 1.40.

Issue #135