### PR TITLE
Add a roundtrip fuzz target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,11 +26,14 @@ members = ["."]
 name = "fuzz_high"
 path = "fuzz_targets/fuzz_high.rs"
 
-[features]
-default = ["fuzzing"]
-fuzzing = ["miniz_oxide_c_api/fuzzing"]
-
-
 [[bin]]
 name = "inflate_nonwrapping"
 path = "fuzz_targets/inflate_nonwrapping.rs"
+
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
+
+[features]
+default = ["fuzzing"]
+fuzzing = ["miniz_oxide_c_api/fuzzing"]

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,11 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate miniz_oxide;
+
+fuzz_target!(|input: (u8, Vec<u8>)| {
+    let compression_level = input.0;
+    let data = input.1;
+    let compressed = miniz_oxide::deflate::compress_to_vec(&data, compression_level);
+    let decompressed = miniz_oxide::inflate::decompress_to_vec(&compressed).expect("Failed to decompress compressed data!");
+    assert_eq!(data, decompressed);
+});


### PR DESCRIPTION
Verifies that any data encoded by miniz_oxide can be correctly decoded.