### PR TITLE
Code size reduction from panic reduction

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -414,6 +414,8 @@ const fn read_u16_le(slice: &[u8], pos: usize) -> u16 {
 pub struct CompressorOxide {
     lz: LZOxide,
     params: ParamsOxide,
+    /// Put HuffmanOxide on the heap with default trick to avoid
+    /// excessive stack copies.
     huff: Box<HuffmanOxide>,
     dict: DictOxide,
 }
@@ -427,8 +429,6 @@ impl CompressorOxide {
         CompressorOxide {
             lz: LZOxide::new(),
             params: ParamsOxide::new(flags),
-            /// Put HuffmanOxide on the heap with default trick to avoid
-            /// excessive stack copies.
             huff: Box::default(),
             dict: DictOxide::new(flags),
         }
@@ -521,8 +521,6 @@ impl Default for CompressorOxide {
         CompressorOxide {
             lz: LZOxide::new(),
             params: ParamsOxide::new(DEFAULT_FLAGS),
-            /// Put HuffmanOxide on the heap with default trick to avoid
-            /// excessive stack copies.
             huff: Box::default(),
             dict: DictOxide::new(DEFAULT_FLAGS),
         }

--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -118,31 +118,30 @@ pub fn compress_to_vec_zlib(input: &[u8], level: u8) -> Vec<u8> {
 }
 
 /// Simple function to compress data to a vec.
-fn compress_to_vec_inner(input: &[u8], level: u8, window_bits: i32, strategy: i32) -> Vec<u8> {
+fn compress_to_vec_inner(mut input: &[u8], level: u8, window_bits: i32, strategy: i32) -> Vec<u8> {
     // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
     let flags = create_comp_flags_from_zip_params(level.into(), window_bits, strategy);
     let mut compressor = CompressorOxide::new(flags);
     let mut output = vec![0; ::core::cmp::max(input.len() / 2, 2)];
 
-    let mut in_pos = 0;
     let mut out_pos = 0;
     loop {
         let (status, bytes_in, bytes_out) = compress(
             &mut compressor,
-            &input[in_pos..],
+            input,
             &mut output[out_pos..],
             TDEFLFlush::Finish,
         );
-
         out_pos += bytes_out;
-        in_pos += bytes_in;
 
         match status {
             TDEFLStatus::Done => {
                 output.truncate(out_pos);
                 break;
             }
-            TDEFLStatus::Okay => {
+            TDEFLStatus::Okay if bytes_in <= input.len() => {
+                input = &input[bytes_in..];
+
                 // We need more space, so resize the vector.
                 if output.len().saturating_sub(out_pos) < 30 {
                     output.resize(output.len() * 2, 0)


### PR DESCRIPTION
Manual bounds checks optimize better, because they don't have additional side effects, and don't need to set a unique panic location each time.

`input = &input[in_consumed..]` optimizes better than advancing `in_pos`.

There's a ton more panics in `decompress`.