### PR TITLE
Optimize match_len == 3

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -50,6 +50,7 @@ macro_rules! decompress_bench {
             let compressed = compress_to_vec(input.as_slice(), $level);
 
             let mut out_len: usize = 0;
+            b.bytes = input.len() as _;
             b.iter(|| unsafe {
                 w($decompress_func(
                     compressed.as_ptr() as *mut c_void,
@@ -70,6 +71,7 @@ macro_rules! compress_bench {
 
             let mut out_len: usize = 0;
             let flags = create_comp_flags_from_zip_params($level, -15, 0) as i32;
+            b.bytes = input.len() as _;
             b.iter(|| unsafe {
                 w($compress_func(
                     input.as_ptr() as *mut c_void,

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -53,7 +53,12 @@ impl HuffmanTable {
         loop {
             // symbol here indicates the position of the left (0) node, if the next bit is 1
             // we add 1 to the lookup position to get the right node.
-            symbol = i32::from(self.tree[(!symbol + ((bit_buf >> code_len) & 1) as i32) as usize]);
+            let tree_index = (!symbol + ((bit_buf >> code_len) & 1) as i32) as usize;
+            debug_assert!(tree_index < self.tree.len());
+            if tree_index >= self.tree.len() {
+                break;
+            }
+            symbol = i32::from(self.tree[tree_index]);
             code_len += 1;
             if symbol >= 0 {
                 break;

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -90,13 +90,14 @@ pub struct DecompressError {
 
 #[cfg(feature = "with-alloc")]
 impl alloc::fmt::Display for DecompressError {
+    #[cold]
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.write_str(match self.status {
             TINFLStatus::FailedCannotMakeProgress => "Truncated input stream",
             TINFLStatus::BadParam => "Invalid output buffer size",
             TINFLStatus::Adler32Mismatch => "Adler32 checksum mismatch",
             TINFLStatus::Failed => "Invalid input data",
-            TINFLStatus::Done => unreachable!(),
+            TINFLStatus::Done => "", // Unreachable
             TINFLStatus::NeedsMoreInput => "Truncated input stream",
             TINFLStatus::HasMoreOutput => "Output size exceeded the specified limit",
         })

--- a/src/lib_oxide.rs
+++ b/src/lib_oxide.rs
@@ -24,12 +24,13 @@ pub enum InternalState {
 }
 
 impl fmt::Debug for InternalState {
+    #[cold]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match &self {
             InternalState::Inflate(_) => "Decompressor",
             InternalState::Deflate(_) => "Compressor",
         };
-        write!(f, "{}", name)
+        f.write_str(name)
     }
 }
 


### PR DESCRIPTION
The fast path has fewer instructions, and gets inlined into decompress.