### PR TITLE
fix(miniz_oxide): Fix version specification for simd-adler32

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -18,7 +18,7 @@ name = "miniz_oxide"
 
 [dependencies]
 adler = { version = "1.0", default-features = false }
-simd-adler32 = { version = "0.3", default-features = false, optional = true }
+simd-adler32 = { version = "0.3.3", default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.


### PR DESCRIPTION
The crate requires `simd-adler32` in version `0.3.3` at a minimum, as that is when the `simd_adler32::Adler32::from_checksum` constructor was introduced. Fix the version specification accordingly.