### PR TITLE
fix(core): Update from `memset` to `.fill`

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -1748,7 +1748,7 @@ fn flush_block(
         }
 
         d.huff.count[0][..MAX_HUFF_SYMBOLS_0].fill(0);
-        d.huff.count[0][..MAX_HUFF_SYMBOLS_1].fill(0);
+        d.huff.count[1][..MAX_HUFF_SYMBOLS_1].fill(0);
 
         d.lz.code_position = 1;
         d.lz.flag_position = 0;


### PR DESCRIPTION
Hey,

We noticed some panicking behavior when compressing data using the `flate2` crate to `gzip`.
Upon investigation, we noticed what seems to be a bug in the latest commit on this file:

https://github.com/Frommi/miniz_oxide/commit/c0662f11528cbc32291bf91d6caa1890774c2729

This PR should solve the bug. Our code is not panicking anymore