### PR TITLE
fix(doc): typo on example code

### DIFF
--- a/miniz_oxide/Readme.md
+++ b/miniz_oxide/Readme.md
@@ -25,7 +25,7 @@ Simple compression/decompression:
 ```rust
 
 use miniz_oxide::deflate::compress_to_vec;
-use miniz_oxide::inflate::decompress_to_vec;
+use miniz_oxide::inflate::decompress_to_vec_with_limit;
 
 fn roundtrip(data: &[u8]) {
     // Compress the input


### PR DESCRIPTION
The example code was not working as is. It has a use for `decompress_to_vec` instead of `decompress_to_vec_with_limit`