### PR TITLE
Avoid stack overflow when initializing HashBuffers.

### DIFF
--- a/miniz_oxide/src/deflate/buffer.rs
+++ b/miniz_oxide/src/deflate/buffer.rs
@@ -2,6 +2,8 @@
 //! to avoid stack copies. Box::new() doesn't at the moment, and using a vec means we would lose
 //! static length info.
 
+use alloc::boxed::Box;
+use alloc::vec;
 use crate::deflate::core::{LZ_DICT_SIZE, MAX_MATCH_LEN};
 
 /// Size of the buffer of lz77 encoded data.
@@ -23,24 +25,26 @@ pub fn update_hash(current_hash: u16, byte: u8) -> u16 {
 }
 
 pub struct HashBuffers {
-    pub dict: [u8; LZ_DICT_FULL_SIZE],
-    pub next: [u16; LZ_DICT_SIZE],
-    pub hash: [u16; LZ_DICT_SIZE],
+    pub dict: Box<[u8; LZ_DICT_FULL_SIZE]>,
+    pub next: Box<[u16; LZ_DICT_SIZE]>,
+    pub hash: Box<[u16; LZ_DICT_SIZE]>,
 }
 
 impl HashBuffers {
     #[inline]
     pub fn reset(&mut self) {
-        *self = HashBuffers::default();
+        self.dict.fill(0);
+        self.next.fill(0);
+        self.hash.fill(0);
     }
 }
 
 impl Default for HashBuffers {
     fn default() -> HashBuffers {
         HashBuffers {
-            dict: [0; LZ_DICT_FULL_SIZE],
-            next: [0; LZ_DICT_SIZE],
-            hash: [0; LZ_DICT_SIZE],
+            dict: vec![0; LZ_DICT_FULL_SIZE].into_boxed_slice().try_into().unwrap(),
+            next: vec![0; LZ_DICT_SIZE].into_boxed_slice().try_into().unwrap(),
+            hash: vec![0; LZ_DICT_SIZE].into_boxed_slice().try_into().unwrap(),
         }
     }
 }

--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -1134,7 +1134,7 @@ pub(crate) struct DictOxide {
     pub max_probes: [u32; 2],
     /// Buffer of input data.
     /// Padded with 1 byte to simplify matching code in `compress_fast`.
-    pub b: Box<HashBuffers>,
+    pub b: HashBuffers,
 
     pub code_buf_dict_pos: usize,
     pub lookahead_size: usize,
@@ -1153,7 +1153,7 @@ impl DictOxide {
     fn new(flags: u32) -> Self {
         DictOxide {
             max_probes: probes_from_flags(flags),
-            b: Box::default(),
+            b: HashBuffers::default(),
             code_buf_dict_pos: 0,
             lookahead_size: 0,
             lookahead_pos: 0,


### PR DESCRIPTION
Before this commit, `Box::default()` that creates default `HashBuffers` would in debug mode create the default `HashBuffers` struct on the stack and then (as a separate step copy it) from the stack into the heap (i.e. into the `Box`). This would require 164098 bytes of stack space and would trigger stack overflow in some scenarios (e.g. when running Chromium tests built in debug-mode on an iOS device - see https://crbug.com/394824910).

I have tested that Chromium tests on iOS pass after changes from this commit - see https://crrev.com/c/6244910 