### PR TITLE
add derive(Serialize, Deserialize) to DecompressorOxide

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["benches/*", "tests/*"]
 name = "miniz_oxide"
 
 [dependencies]
-adler2 = { version = "2.0", default-features = false}
+adler2 = { version = "2.0", default-features = false }
 simd-adler32 = { version = "0.3.3", default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
@@ -31,17 +31,19 @@ serde = { version = "1.0.217", features = ["derive"], optional = true }
 ## Messes with minimum rust version and drags in deps just for running tests
 ## so just comment out for now and enable manually when needed for enabling benches
 #criterion = "0.5"
-rmp-serde = "1.3.0"
+
+## Enable when running "with-serde" tests
+#rmp-serde = "1.3.0"
 
 [[bench]]
 name = "benchmark"
 harness = false
 
 [features]
-default = ["with-alloc", "with-serde"]
+default = ["with-alloc"]
 with-alloc = []
 std = []
-with-serde = ["std", "dep:serde"]
+with-serde = ["std", "serde"]
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -25,7 +25,7 @@ simd-adler32 = { version = "0.3.3", default-features = false, optional = true }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
 compiler_builtins = { version = '0.1.2', optional = true }
-serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 ## Messes with minimum rust version and drags in deps just for running tests

--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -25,20 +25,23 @@ simd-adler32 = { version = "0.3.3", default-features = false, optional = true }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
 compiler_builtins = { version = '0.1.2', optional = true }
+serde = { version = "1.0.217", features = ["derive"], optional = true }
 
 [dev-dependencies]
 ## Messes with minimum rust version and drags in deps just for running tests
 ## so just comment out for now and enable manually when needed for enabling benches
 #criterion = "0.5"
+rmp-serde = "1.3.0"
 
 [[bench]]
 name = "benchmark"
 harness = false
 
 [features]
-default = ["with-alloc"]
+default = ["with-alloc", "with-serde"]
 with-alloc = []
 std = []
+with-serde = ["std", "dep:serde"]
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -9,19 +9,27 @@ use ::core::convert::TryInto;
 
 use self::output_buffer::{InputWrapper, OutputBuffer};
 
+#[cfg(feature = "with-serde")]
+use crate::serde::big_array::BigArray;
+#[cfg(feature = "with-serde")]
+use serde::{Deserialize, Serialize};
+
 pub const TINFL_LZ_DICT_SIZE: usize = 32_768;
 
 /// A struct containing huffman code lengths and the huffman code tree used by the decompressor.
 #[derive(Clone)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 struct HuffmanTable {
     /// Fast lookup table for shorter huffman codes.
     ///
     /// See `HuffmanTable::fast_lookup`.
+    #[cfg_attr(feature = "with-serde", serde(with = "BigArray"))]
     pub look_up: [i16; FAST_LOOKUP_SIZE as usize],
     /// Full huffman tree.
     ///
     /// Positive values are edge nodes/symbols, negative values are
     /// parent nodes/references to other nodes.
+    #[cfg_attr(feature = "with-serde", serde(with = "BigArray"))]
     pub tree: [i16; MAX_HUFF_TREE_SIZE],
 }
 
@@ -172,6 +180,7 @@ enum HuffmanTableType {
 /// Main decompression struct.
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub struct DecompressorOxide {
     /// Current state of the decompressor.
     state: core::State,
@@ -203,12 +212,15 @@ pub struct DecompressorOxide {
     bit_buf: BitBuffer,
     /// Huffman tables.
     tables: [HuffmanTable; MAX_HUFF_TABLES],
+
+    #[cfg_attr(feature = "with-serde", serde(with = "BigArray"))]
     code_size_literal: [u8; MAX_HUFF_SYMBOLS_0],
     code_size_dist: [u8; MAX_HUFF_SYMBOLS_1],
     code_size_huffman: [u8; MAX_HUFF_SYMBOLS_2],
     /// Raw block header.
     raw_header: [u8; 4],
     /// Huffman length codes.
+    #[cfg_attr(feature = "with-serde", serde(with = "BigArray"))]
     len_codes: [u8; MAX_HUFF_SYMBOLS_0 + MAX_HUFF_SYMBOLS_1 + 137],
 }
 
@@ -296,6 +308,7 @@ impl Default for DecompressorOxide {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 enum State {
     Start = 0,

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -31,6 +31,8 @@ extern crate alloc;
 #[cfg(feature = "with-alloc")]
 pub mod deflate;
 pub mod inflate;
+#[cfg(feature = "with-serde")]
+pub mod serde;
 mod shared;
 
 pub use crate::shared::update_adler32 as mz_adler32_oxide;

--- a/miniz_oxide/src/serde/big_array.rs
+++ b/miniz_oxide/src/serde/big_array.rs
@@ -1,0 +1,70 @@
+use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
+use serde::ser::{Serialize, SerializeTuple, Serializer};
+use std::fmt;
+use std::marker::PhantomData;
+
+pub trait BigArray<'de>: Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+macro_rules! big_array {
+    ($($len:expr,)+) => {
+        $(
+            impl<'de, T> BigArray<'de> for [T; $len]
+                where T: Default + Copy + Serialize + Deserialize<'de>
+            {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: Serializer
+                {
+                    let mut seq = serializer.serialize_tuple(self.len())?;
+                    for elem in &self[..] {
+                        seq.serialize_element(elem)?;
+                    }
+                    seq.end()
+                }
+
+                fn deserialize<D>(deserializer: D) -> Result<[T; $len], D::Error>
+                    where D: Deserializer<'de>
+                {
+                    struct ArrayVisitor<T> {
+                        element: PhantomData<T>,
+                    }
+
+                    impl<'de, T> Visitor<'de> for ArrayVisitor<T>
+                        where T: Default + Copy + Deserialize<'de>
+                    {
+                        type Value = [T; $len];
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str(concat!("an array of length ", $len))
+                        }
+
+                        fn visit_seq<A>(self, mut seq: A) -> Result<[T; $len], A::Error>
+                            where A: SeqAccess<'de>
+                        {
+                            let mut arr = [T::default(); $len];
+                            for i in 0..$len {
+                                arr[i] = seq.next_element()?
+                                    .ok_or_else(|| Error::invalid_length(i, &self))?;
+                            }
+                            Ok(arr)
+                        }
+                    }
+
+                    let visitor = ArrayVisitor { element: PhantomData };
+                    deserializer.deserialize_tuple($len, visitor)
+                }
+            }
+        )+
+    }
+}
+
+big_array! {
+    40, 48, 50, 56, 64, 72, 96, 100, 128, 160, 192, 200, 224, 256, 288, 384, 457, 512,
+    576, 768, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
+}

--- a/miniz_oxide/src/serde/mod.rs
+++ b/miniz_oxide/src/serde/mod.rs
@@ -1,0 +1,1 @@
+pub mod big_array;

--- a/miniz_oxide/tests/test_serde.rs
+++ b/miniz_oxide/tests/test_serde.rs
@@ -65,12 +65,13 @@ pub fn serde_serialize_deserialize_decompressor(
 enum PartialResult<T, E> {
     /// out_buf
     Ok(T),
-    /// decomp, input_pos, out_buf
+
+    /// input_pos, decomp, out_buf
     Partial(usize, Box<DecompressorOxide>, T),
     Err(E),
 }
 
-/// Decompressed partially out_buf.
+/// Decompressed partially to out_buf.
 ///
 /// Assumes that out_buf contains already decompressed data.
 fn decompress_to_vec_partial(

--- a/miniz_oxide/tests/test_serde.rs
+++ b/miniz_oxide/tests/test_serde.rs
@@ -1,0 +1,137 @@
+#![cfg(feature = "with-serde")]
+use miniz_oxide::{
+    deflate::compress_to_vec,
+    inflate::{
+        core::{decompress, inflate_flags, DecompressorOxide},
+        decompress_to_vec, TINFLStatus,
+    },
+};
+
+/// Test pause and resume of DecompressorOxide state
+#[test]
+fn serde_resume_inflate_state() {
+    let data = include_bytes!("./test_data/numbers.deflate");
+    let decompressed_fully = decompress_to_vec(data.as_slice()).unwrap();
+
+    let (decomp, in_pos, out_buf) = {
+        let decomp = Box::<DecompressorOxide>::default();
+        let out_buf = Vec::new();
+        let result = decompress_to_vec_partial(decomp, &data[..], out_buf, 32 * 1024);
+
+        match result {
+            PartialResult::Ok(_) => panic!("expected partial read"),
+            PartialResult::Err(err) => panic!("expected partial read, err: {err:?}"),
+
+            PartialResult::Partial(in_pos, decomp, out_buf) => {
+                println!("partial read len={}", out_buf.len());
+                (decomp, in_pos, out_buf)
+            }
+        }
+    };
+    println!("save at in_pos={in_pos}");
+
+    // here the 'save' and 'restore' happens
+    let (in_pos, decomp) = serde_serialize_deserialize_decompressor((in_pos, decomp));
+
+    println!("resume at in_pos={in_pos}");
+
+    let result = decompress_to_vec_partial(decomp, &data[in_pos..], out_buf, 1_000_000);
+
+    let out_buf = match result {
+        PartialResult::Partial(_, _, _) => panic!("expected full read"),
+        PartialResult::Err(err) => panic!("expected full read, err: {err:?}"),
+
+        PartialResult::Ok(out_buf) => out_buf,
+    };
+
+    assert_eq!(out_buf, decompressed_fully);
+}
+
+/// Saves the state and 'resumes' it
+pub fn serde_serialize_deserialize_decompressor(
+    decomp: (usize, Box<DecompressorOxide>),
+) -> (usize, Box<DecompressorOxide>) {
+    let decompressor_state_msgpack = rmp_serde::to_vec(&decomp).unwrap();
+    let decompressor_state_compressed = compress_to_vec(&decompressor_state_msgpack, 7);
+
+    dbg!(decompressor_state_msgpack.len());
+    dbg!(decompressor_state_compressed.len());
+
+    let decompressor_state_msgpack = decompress_to_vec(&decompressor_state_compressed).unwrap();
+    rmp_serde::from_slice(&decompressor_state_msgpack).unwrap()
+}
+
+#[derive(Clone)]
+enum PartialResult<T, E> {
+    /// out_buf
+    Ok(T),
+    /// decomp, input_pos, out_buf
+    Partial(usize, Box<DecompressorOxide>, T),
+    Err(E),
+}
+
+/// Decompressed partially out_buf.
+///
+/// Assumes that out_buf contains already decompressed data.
+fn decompress_to_vec_partial(
+    decomp: Box<DecompressorOxide>,
+    input: &[u8],
+    out_buf: Vec<u8>,
+    pause_output_size: usize,
+) -> PartialResult<Vec<u8>, TINFLStatus> {
+    decompress_to_vec_partial_inner(decomp, input, out_buf, 0, pause_output_size)
+}
+
+fn decompress_to_vec_partial_inner<'b>(
+    mut decomp: Box<DecompressorOxide>,
+    input: &[u8],
+    mut out_buf: Vec<u8>,
+    flags: u32,
+    pause_output_size: usize,
+) -> PartialResult<Vec<u8>, TINFLStatus> {
+    let flags = flags | inflate_flags::TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
+    let mut out_pos = out_buf.len();
+    let mut in_pos = 0;
+
+    let additional = out_buf.len().max(16);
+    let new_size = out_buf
+        .len()
+        .saturating_add(additional)
+        .min(pause_output_size);
+    out_buf.resize(new_size, 0);
+
+    loop {
+        // Wrap the whole output slice so we know we have enough of the
+        // decompressed data for matches.
+        let (status, in_consumed, out_consumed) =
+            decompress(&mut decomp, &input[in_pos..], &mut out_buf, out_pos, flags);
+        out_pos += out_consumed;
+
+        match status {
+            TINFLStatus::Done => {
+                out_buf.truncate(out_pos);
+                return PartialResult::Ok(out_buf);
+            }
+
+            TINFLStatus::HasMoreOutput => {
+                // in_consumed is not expected to be out of bounds,
+                // but the check eliminates a panicking code path
+                if in_consumed > input.len() {
+                    return PartialResult::Err(TINFLStatus::HasMoreOutput);
+                }
+                in_pos += in_consumed;
+
+                // if the buffer has already reached the size limit, return partial result
+                if out_buf.len() >= pause_output_size {
+                    out_buf.truncate(out_pos);
+                    return PartialResult::Partial(in_pos, decomp, out_buf);
+                }
+                // calculate the new length, capped at `pause_output_size`
+                let new_len = out_buf.len().saturating_mul(2).min(pause_output_size);
+                out_buf.resize(new_len, 0);
+            }
+
+            _ => return PartialResult::Err(status),
+        }
+    }
+}


### PR DESCRIPTION
Fixes 
- https://github.com/Frommi/miniz_oxide/issues/165
- https://github.com/bearcove/rc-zip/issues/99

I know this PR will not be merged, but it proves that state saving is actually possible!

Entire `DecompressorOxide` state compresses into only 356 bytes, for simple test case.

```
partial read len=32768
save at in_pos=11729
[miniz_oxide/tests/test_serde.rs:57:5] decompressor_state_msgpack.len() = 11824
[miniz_oxide/tests/test_serde.rs:58:5] decompressor_state_compressed.len() = 356
resume at in_pos=11729
```

So fast-seekable zip files are possible 😄 
