### PR TITLE
README: note that no_std also works with provided memory slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Main library [![Crates.io](https://img.shields.io/crates/v/miniz_oxide.svg)](htt
 C API [![Crates.io](https://img.shields.io/crates/v/miniz_oxide_c_api.svg)](https://crates.io/crates/miniz_oxide_c_api)[![Docs](https://docs.rs/miniz_oxide_c_api/badge.svg)](https://docs.rs/miniz_oxide_c_api)
 
 # miniz_oxide
-Pure rust replacement for the [miniz](https://github.com/richgel999/miniz) deflate/zlib encoder/decoder using no unsafe code. Builds in [no_std](https://docs.rust-embedded.org/book/intro/no-std.html) mode, though requires the use of `alloc` and `collections` crates.
+Pure rust replacement for the [miniz](https://github.com/richgel999/miniz) deflate/zlib encoder/decoder using no unsafe code. Builds in [no_std](https://docs.rust-embedded.org/book/intro/no-std.html) mode, though requires the use of `alloc` and `collections` crates or preallocated memory slices.
 
 This project is organized into a C API shell and a rust crate.
 The Rust crate is found in the [miniz_oxide subdirectory](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide).


### PR DESCRIPTION
The README first led me to beliving that miniz_oxide _only_ works with an allocator.
Through https://github.com/oreboot/oreboot/issues/772 I learned that it also works with preallocated slices with `default-features = false` as described in the docs at https://crates.io/crates/miniz_oxide - which is what I just tested, and Oxide's phbl does as well. :)