### PR TITLE
Add API to support random access at block boundaries

### DIFF
--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -17,6 +17,7 @@ const TINFL_STATUS_FAILED: i32 = -1;
 const TINFL_STATUS_DONE: i32 = 0;
 const TINFL_STATUS_NEEDS_MORE_INPUT: i32 = 1;
 const TINFL_STATUS_HAS_MORE_OUTPUT: i32 = 2;
+const TINFL_STATUS_BLOCK_BOUNDARY: i32 = 3;
 
 /// Return status codes.
 #[repr(i8)]
@@ -59,6 +60,17 @@ pub enum TINFLStatus {
 
     /// There is still pending data that didn't fit in the output buffer.
     HasMoreOutput = TINFL_STATUS_HAS_MORE_OUTPUT as i8,
+
+    /// Reached the end of a deflate block, and the start of the next block.
+    ///
+    /// At this point, you can suspend decompression and later resume with a new `DecompressorOxide`.
+    /// The only state that must be preserved is [`DecompressorOxide::get_block_boundary_state()`],
+    /// plus the last 32KiB of the output buffer (or less if you know the stream was compressed with
+    /// a smaller window size).
+    ///
+    /// This is only returned if you use the
+    /// [`TINFL_FLAG_STOP_ON_BLOCK_BOUNDARY`][core::inflate_flags::TINFL_FLAG_STOP_ON_BLOCK_BOUNDARY] flag.
+    BlockBoundary = TINFL_STATUS_BLOCK_BOUNDARY as i8,
 }
 
 impl TINFLStatus {
@@ -72,6 +84,7 @@ impl TINFLStatus {
             TINFL_STATUS_DONE => Some(Done),
             TINFL_STATUS_NEEDS_MORE_INPUT => Some(NeedsMoreInput),
             TINFL_STATUS_HAS_MORE_OUTPUT => Some(HasMoreOutput),
+            TINFL_STATUS_BLOCK_BOUNDARY => Some(BlockBoundary),
             _ => None,
         }
     }
@@ -99,6 +112,7 @@ impl alloc::fmt::Display for DecompressError {
             TINFLStatus::Done => "", // Unreachable
             TINFLStatus::NeedsMoreInput => "Truncated input stream",
             TINFLStatus::HasMoreOutput => "Output size exceeded the specified limit",
+            TINFLStatus::BlockBoundary => "Reached end of a deflate block",
         })
     }
 }

--- a/src/tinfl.rs
+++ b/src/tinfl.rs
@@ -55,6 +55,7 @@ impl From<TINFLStatus> for tinfl_status {
             TINFLStatus::Done => TINFL_STATUS_DONE,
             TINFLStatus::NeedsMoreInput => TINFL_STATUS_NEEDS_MORE_INPUT,
             TINFLStatus::HasMoreOutput => TINFL_STATUS_HAS_MORE_OUTPUT,
+            TINFLStatus::BlockBoundary => panic!("not supported in C API"),
         }
     }
 }


### PR DESCRIPTION
See comment in #166 for rationale. Basically, this allows users to implement random access in the same way as zlib's [`zran.c`](https://github.com/madler/zlib/blob/develop/examples/zran.c), and avoids the downsides of serializing the entire `DecompressorOxide` state.

I've used this API in https://github.com/zaynar/indexed_deflate (WIP) and done some very basic testing on a few large .gz files.

Currently that code only uses `BlockBoundaryState::num_bits`. The other state fields are completely untested. If the basic concept of this patch seems acceptable, I can try to add some better testing here.