### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # stable interface of this crate.
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
-compiler_builtins = { version = '0.1.2', optional = true }
 
 
 [dev-dependencies]
@@ -45,7 +44,7 @@ block-boundary = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'adler2/rustc-dep-of-std']
+rustc-dep-of-std = ['core', 'alloc', 'adler2/rustc-dep-of-std']
 
 simd = ['simd-adler32']
 


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993