### PR TITLE
Fix Typos in Comments: "hierachy" → "hierarchy", "udpating" → "updating"

### DIFF
--- a/benches/data/code
+++ b/benches/data/code
@@ -5892,7 +5892,7 @@ void mem_cgroup_swapout(struct page *page, swp_entry_t entry)
 	 * Interrupts should be disabled here because the caller holds the
 	 * mapping->tree_lock lock which is taken with interrupts-off. It is
 	 * important here to have the interrupts disabled because it is the
-	 * only synchronisation we have for udpating the per-CPU variables.
+	 * only synchronisation we have for updating the per-CPU variables.
 	 */
 	VM_BUG_ON(!irqs_disabled());
 	mem_cgroup_charge_statistics(memcg, page, false, -1);

--- a/benches/data/code
+++ b/benches/data/code
@@ -4265,7 +4265,7 @@ mem_cgroup_css_alloc(struct cgroup_subsys_state *parent_css)
 		page_counter_init(&memcg->kmem, NULL);
 		page_counter_init(&memcg->tcpmem, NULL);
 		/*
-		 * Deeper hierachy with use_hierarchy == false doesn't make
+		 * Deeper hierarchy with use_hierarchy == false doesn't make
 		 * much sense so let cgroup subsystem know about this
 		 * unfortunate state in our controller.
 		 */


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling errors in code comments, improving clarity and consistency. 