### PR TITLE
chore: Do not force `std` with `serde` feature

### DIFF
--- a/miniz_oxide/Cargo.toml
+++ b/miniz_oxide/Cargo.toml
@@ -19,7 +19,7 @@ name = "miniz_oxide"
 [dependencies]
 adler2 = { version = "2.0", default-features = false }
 simd-adler32 = { version = "0.3.3", default-features = false, optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive", "alloc"], default-features = false, optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
@@ -39,7 +39,7 @@ harness = false
 [features]
 default = ["with-alloc"]
 with-alloc = []
-std = []
+std = ["serde?/std"]
 block-boundary = []
 
 # Internal feature, only used when building as part of libstd, not part of the

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -23,7 +23,7 @@ fn roundtrip(data: &[u8]) {
 "##
 )]
 #![forbid(unsafe_code)]
-#![cfg_attr(all(not(feature = "std"), not(feature = "serde")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "with-alloc")]
 extern crate alloc;

--- a/miniz_oxide/src/serde/big_array.rs
+++ b/miniz_oxide/src/serde/big_array.rs
@@ -1,7 +1,7 @@
 use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeTuple, Serializer};
-use std::fmt;
-use std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
 
 pub trait BigArray<'de>: Sized {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
## Overview

Removes the implication that enabling the `serde` feature enables `std`. 