### PR TITLE
Add decompress_with_limit to handle ring buffers

### DIFF
--- a/miniz_oxide/src/inflate/output_buffer.rs
+++ b/miniz_oxide/src/inflate/output_buffer.rs
@@ -6,12 +6,17 @@
 pub struct OutputBuffer<'a> {
     slice: &'a mut [u8],
     position: usize,
+    max: usize,
 }
 
 impl<'a> OutputBuffer<'a> {
     #[inline]
-    pub fn from_slice_and_pos(slice: &'a mut [u8], position: usize) -> OutputBuffer<'a> {
-        OutputBuffer { slice, position }
+    pub fn from_slice_pos_and_max(slice: &'a mut [u8], position: usize, max_count: usize) -> OutputBuffer<'a> {
+        let mut max = position.saturating_add(max_count);
+        if max > slice.len() {
+            max = slice.len();
+        }
+        OutputBuffer { slice, position, max }
     }
 
     #[inline(always)]
@@ -45,7 +50,7 @@ impl<'a> OutputBuffer<'a> {
 
     #[inline]
     pub const fn bytes_left(&self) -> usize {
-        self.slice.len() - self.position
+        self.max - self.position
     }
 
     #[inline(always)]


### PR DESCRIPTION
Decompress does not limit how many bytes it writes to the buffer.

This means that we will lose any byte present before the call, which is not a problem when we decompress all in one go, but is annoying when we want to use the buffer as a ring buffer.

So I added a decompress_with_limit which takes a maximum number of bytes to decompress. With it, it is possible to use the output buffer as a ring buffer, just don't overwrite bytes that have not yet been consumed.
