### PR TITLE
inflate/deflate: cooperative cancellation via a vendored StopCheck (no new dependencies)

### DIFF
--- a/miniz_oxide/src/deflate/mod.rs
+++ b/miniz_oxide/src/deflate/mod.rs
@@ -144,6 +144,84 @@ pub fn compress_to_vec_zlib(input: &[u8], level: u8) -> Vec<u8> {
     compress_to_vec_inner(input, level, 1, 0)
 }
 
+/// Error returned when [`compress_to_vec_with_stop`] is stopped by its callback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompressStopped;
+
+impl ::core::fmt::Display for CompressStopped {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.write_str("Stopped by cancellation callback")
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for CompressStopped {}
+
+/// Compress the input data to a vector, using the specified compression level
+/// (0-10) and an optional zlib wrapper, polling `stop` about every 64 KiB of
+/// consumed input.
+///
+/// If `stop` signals a stop, compression ends early with [`CompressStopped`]
+/// and the data compressed so far is discarded.
+///
+/// [`StopCheck::none()`][crate::stop::StopCheck::none] never stops and produces
+/// the same output as [`compress_to_vec`] / [`compress_to_vec_zlib`].
+pub fn compress_to_vec_with_stop(
+    input: &[u8],
+    level: u8,
+    zlib_wrapper: bool,
+    stop: &crate::stop::StopCheck,
+) -> Result<Vec<u8>, CompressStopped> {
+    // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
+    let flags = create_comp_flags_from_zip_params(level.into(), i32::from(zlib_wrapper), 0);
+    let mut compressor = CompressorOxide::new(flags);
+    let mut output = vec![0; ::core::cmp::max(input.len() / 2, 2)];
+
+    // Compression has no output amplification, so feeding the streaming
+    // compressor bounded input chunks bounds the work between polls. Block
+    // emission is driven by the compressor's internal buffers, not call
+    // boundaries, so the output matches the one-shot functions.
+    const STOP_CHUNK: usize = 64 * 1024;
+
+    let mut in_pos = 0;
+    let mut out_pos = 0;
+    loop {
+        if stop.should_stop() {
+            return Err(CompressStopped);
+        }
+
+        let chunk_end = ::core::cmp::min(in_pos + STOP_CHUNK, input.len());
+        let last = chunk_end == input.len();
+        let (status, bytes_in, bytes_out) = compress(
+            &mut compressor,
+            &input[in_pos..chunk_end],
+            &mut output[out_pos..],
+            if last {
+                TDEFLFlush::Finish
+            } else {
+                TDEFLFlush::None
+            },
+        );
+        in_pos += bytes_in;
+        out_pos += bytes_out;
+
+        match status {
+            TDEFLStatus::Done => {
+                output.truncate(out_pos);
+                return Ok(output);
+            }
+            TDEFLStatus::Okay => {
+                // We may need more space, so resize the vector.
+                if output.len().saturating_sub(out_pos) < 30 {
+                    output.resize(output.len() * 2, 0)
+                }
+            }
+            // Not supposed to happen unless there is a bug.
+            _ => panic!("Bug! Unexpectedly failed to compress!"),
+        }
+    }
+}
+
 /// Simple function to compress data to a vec.
 fn compress_to_vec_inner(mut input: &[u8], level: u8, window_bits: i32, strategy: i32) -> Vec<u8> {
     // The comp flags function sets the zlib flag if the window_bits parameter is > 0.
@@ -258,5 +336,49 @@ mod test {
         // (The optimal compressed length would be 5, but neither miniz nor zlib manages that either
         // as neither checks matches against the byte at index 0.)
         assert!(c.len() <= 6);
+    }
+
+    mod stop {
+        use crate::deflate::{compress_to_vec_with_stop, compress_to_vec_zlib, CompressStopped};
+        use crate::stop::StopCheck;
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Returns a check that stops after `n` polls.
+        fn stop_after(n: usize) -> StopCheck {
+            let remaining = Arc::new(AtomicUsize::new(n));
+            StopCheck::new(move || {
+                if remaining.load(Ordering::Relaxed) == 0 {
+                    true
+                } else {
+                    remaining.fetch_sub(1, Ordering::Relaxed);
+                    false
+                }
+            })
+        }
+
+        /// Spans several 64 KiB poll chunks.
+        fn payload() -> Vec<u8> {
+            (0..512 * 1024).map(|i| (i % 251) as u8).collect()
+        }
+
+        #[test]
+        fn never_stopping_matches_plain_compress() {
+            let raw = payload();
+            let plain = compress_to_vec_zlib(&raw, 6);
+            let with_stop = compress_to_vec_with_stop(&raw, 6, true, &StopCheck::none()).unwrap();
+            assert_eq!(plain, with_stop);
+        }
+
+        #[test]
+        fn stopping_returns_error() {
+            let raw = payload();
+            for checks_allowed in [0, 2] {
+                let err = compress_to_vec_with_stop(&raw, 6, true, &stop_after(checks_allowed))
+                    .unwrap_err();
+                assert_eq!(err, CompressStopped);
+            }
+        }
     }
 }

--- a/miniz_oxide/src/inflate/core.rs
+++ b/miniz_oxide/src/inflate/core.rs
@@ -1218,6 +1218,13 @@ fn apply_match(
 /// Currently we don't do this here, but this function does avoid having to jump through the
 /// big match loop on each state change(as rust does not have fallthrough or gotos at the moment),
 /// and already improves decompression speed a fair bit.
+/// How often, in output bytes, the optional stop callback is polled in the fast
+/// decompression loop. 16 KiB keeps the polling interval in the tens of
+/// microseconds at typical decompression speeds while staying off the
+/// per-symbol hot path.
+const STOP_CHECK_INTERVAL: usize = 16 * 1024;
+
+#[allow(clippy::too_many_arguments)]
 fn decompress_fast(
     r: &mut DecompressorOxide,
     in_iter: &mut InputWrapper,
@@ -1225,6 +1232,8 @@ fn decompress_fast(
     flags: u32,
     local_vars: &mut LocalVars,
     out_buf_size_mask: usize,
+    stop: Option<&dyn Fn() -> bool>,
+    next_stop_check: &mut usize,
 ) -> (TINFLStatus, State) {
     // Make a local copy of the most used variables, to avoid having to update and read from values
     // in a random memory location and to encourage more register use.
@@ -1233,6 +1242,19 @@ fn decompress_fast(
 
     let status: TINFLStatus = 'o: loop {
         state = State::DecodeLitlen;
+
+        // Poll the stop callback about every STOP_CHECK_INTERVAL output bytes.
+        // When no callback is set, next_stop_check is usize::MAX and this is a
+        // single never-taken comparison.
+        if out_buf.position() >= *next_stop_check {
+            if let Some(stop) = stop {
+                if stop() {
+                    break 'o TINFLStatus::Stopped;
+                }
+            }
+            *next_stop_check = out_buf.position() + STOP_CHECK_INTERVAL;
+        }
+
         loop {
             // This function assumes that there is at least 259 bytes left in the output buffer,
             // and that there is at least 14 bytes left in the input buffer. 14 input bytes:
@@ -1425,6 +1447,21 @@ pub fn decompress_with_limit(
     out_max: usize,
     flags: u32,
 ) -> (TINFLStatus, usize, usize) {
+    decompress_internal(r, in_buf, out, out_pos, out_max, flags, None)
+}
+
+/// Same as [`decompress_with_limit()`], but polls `stop` at each block boundary and
+/// roughly every [`STOP_CHECK_INTERVAL`] output bytes in the fast path, ending
+/// decompression with [`TINFLStatus::Stopped`] if it returns true.
+pub(crate) fn decompress_internal(
+    r: &mut DecompressorOxide,
+    in_buf: &[u8],
+    out: &mut [u8],
+    out_pos: usize,
+    out_max: usize,
+    flags: u32,
+    stop: Option<&dyn Fn() -> bool>,
+) -> (TINFLStatus, usize, usize) {
     let out_buf_size_mask = if flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF != 0 {
         usize::MAX
     } else {
@@ -1455,6 +1492,12 @@ pub fn decompress_with_limit(
         dist: r.dist,
         counter: r.counter,
         num_extra: r.num_extra,
+    };
+
+    // usize::MAX disables position-based stop polling when no callback is set.
+    let mut next_stop_check = match stop {
+        Some(_) => out_pos + STOP_CHECK_INTERVAL,
+        None => usize::MAX,
     };
 
     let mut status = 'state_machine: loop {
@@ -1492,6 +1535,10 @@ pub fn decompress_with_limit(
 
             // Read the block header and jump to the relevant section depending on the block type.
             ReadBlockHeader => generate_state!(state, 'state_machine, {
+                // Poll the stop callback at each block boundary.
+                if stop.map_or(false, |stop| stop()) {
+                    break 'state_machine TINFLStatus::Stopped;
+                }
                 read_bits(&mut l, 3, &mut in_iter, flags, |l, bits| {
                     r.finish = (bits & 1) as u8;
                     r.block_type = ((bits >> 1) & 3) as u8;
@@ -1764,6 +1811,8 @@ pub fn decompress_with_limit(
                         flags,
                         &mut l,
                         out_buf_size_mask,
+                        stop,
+                        &mut next_stop_check,
                     );
 
                     state = new_state;

--- a/miniz_oxide/src/inflate/mod.rs
+++ b/miniz_oxide/src/inflate/mod.rs
@@ -12,6 +12,7 @@ pub mod stream;
 #[cfg(not(feature = "rustc-dep-of-std"))]
 use self::core::*;
 
+const TINFL_STATUS_STOPPED: i32 = -5;
 const TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS: i32 = -4;
 const TINFL_STATUS_BAD_PARAM: i32 = -3;
 const TINFL_STATUS_ADLER32_MISMATCH: i32 = -2;
@@ -28,6 +29,11 @@ const TINFL_STATUS_BLOCK_BOUNDARY: i32 = 3;
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TINFLStatus {
+    /// Decompression was stopped early by the stop callback.
+    ///
+    /// The data decompressed so far is valid.
+    Stopped = TINFL_STATUS_STOPPED as i8,
+
     /// More input data was expected, but the caller indicated that there was no more data, so the
     /// input stream is likely truncated.
     ///
@@ -83,6 +89,7 @@ impl TINFLStatus {
     pub fn from_i32(value: i32) -> Option<TINFLStatus> {
         use self::TINFLStatus::*;
         match value {
+            TINFL_STATUS_STOPPED => Some(Stopped),
             TINFL_STATUS_FAILED_CANNOT_MAKE_PROGRESS => Some(FailedCannotMakeProgress),
             TINFL_STATUS_BAD_PARAM => Some(BadParam),
             TINFL_STATUS_ADLER32_MISMATCH => Some(Adler32Mismatch),
@@ -112,6 +119,7 @@ impl alloc::fmt::Display for DecompressError {
     #[cold]
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.write_str(match self.status {
+            TINFLStatus::Stopped => "Stopped by cancellation callback",
             TINFLStatus::FailedCannotMakeProgress => "Truncated input stream",
             TINFLStatus::BadParam => "Invalid output buffer size",
             TINFLStatus::Adler32Mismatch => "Adler32 checksum mismatch",
@@ -144,7 +152,7 @@ fn decompress_error(status: TINFLStatus, output: Vec<u8>) -> Result<Vec<u8>, Dec
 #[inline]
 #[cfg(feature = "with-alloc")]
 pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, DecompressError> {
-    decompress_to_vec_inner(input, 0, usize::MAX)
+    decompress_to_vec_inner(input, 0, usize::MAX, None)
 }
 
 /// Decompress the deflate-encoded data (with a zlib wrapper) in `input` to a vector.
@@ -161,6 +169,7 @@ pub fn decompress_to_vec_zlib(input: &[u8]) -> Result<Vec<u8>, DecompressError> 
         input,
         inflate_flags::TINFL_FLAG_PARSE_ZLIB_HEADER,
         usize::MAX,
+        None,
     )
 }
 
@@ -179,7 +188,7 @@ pub fn decompress_to_vec_with_limit(
     input: &[u8],
     max_size: usize,
 ) -> Result<Vec<u8>, DecompressError> {
-    decompress_to_vec_inner(input, 0, max_size)
+    decompress_to_vec_inner(input, 0, max_size, None)
 }
 
 /// Decompress the deflate-encoded data (with a zlib wrapper) in `input` to a vector.
@@ -196,7 +205,45 @@ pub fn decompress_to_vec_zlib_with_limit(
     input: &[u8],
     max_size: usize,
 ) -> Result<Vec<u8>, DecompressError> {
-    decompress_to_vec_inner(input, inflate_flags::TINFL_FLAG_PARSE_ZLIB_HEADER, max_size)
+    decompress_to_vec_inner(
+        input,
+        inflate_flags::TINFL_FLAG_PARSE_ZLIB_HEADER,
+        max_size,
+        None,
+    )
+}
+
+/// Decompress deflate-encoded data (with an optional zlib wrapper) to a vector,
+/// polling `stop` at each deflate block boundary and roughly every 16 KiB of
+/// decompressed output.
+///
+/// If `stop` signals a stop, decompression ends early and the returned
+/// [`DecompressError`] has the status [`TINFLStatus::Stopped`] and holds the
+/// data decompressed so far.
+///
+/// [`StopCheck::none()`][crate::stop::StopCheck::none] installs no callback and
+/// takes the same code path as [`decompress_to_vec_with_limit`].
+#[inline]
+#[cfg(feature = "with-alloc")]
+pub fn decompress_to_vec_with_stop(
+    input: &[u8],
+    zlib_header: bool,
+    max_size: usize,
+    stop: &crate::stop::StopCheck,
+) -> Result<Vec<u8>, DecompressError> {
+    let flags = if zlib_header {
+        inflate_flags::TINFL_FLAG_PARSE_ZLIB_HEADER
+    } else {
+        0
+    };
+    let callback;
+    let stop = if stop.may_stop() {
+        callback = || stop.should_stop();
+        Some(&callback as &dyn Fn() -> bool)
+    } else {
+        None
+    };
+    decompress_to_vec_inner(input, flags, max_size, stop)
 }
 
 /// Backend of various to-[`Vec`] decompressions.
@@ -207,6 +254,7 @@ fn decompress_to_vec_inner(
     mut input: &[u8],
     flags: u32,
     max_output_size: usize,
+    stop: Option<&dyn Fn() -> bool>,
 ) -> Result<Vec<u8>, DecompressError> {
     let flags = flags | inflate_flags::TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
     let mut ret: Vec<u8> = vec![0; input.len().saturating_mul(2).min(max_output_size)];
@@ -217,8 +265,15 @@ fn decompress_to_vec_inner(
     loop {
         // Wrap the whole output slice so we know we have enough of the
         // decompressed data for matches.
-        let (status, in_consumed, out_consumed) =
-            decompress(&mut decomp, input, &mut ret, out_pos, flags);
+        let (status, in_consumed, out_consumed) = decompress_internal(
+            &mut decomp,
+            input,
+            &mut ret,
+            out_pos,
+            usize::MAX,
+            flags,
+            stop,
+        );
         out_pos += out_consumed;
 
         match status {
@@ -387,5 +442,66 @@ mod test {
         let mut out = [0_u8; 3_usize];
         let r = decompress_slice_iter_to_slice(&mut out, ENCODED.chunks(7), true, false);
         assert!(r.is_err());
+    }
+
+    mod stop {
+        use crate::alloc::sync::Arc;
+        use crate::alloc::vec::Vec;
+        use crate::deflate::compress_to_vec_zlib;
+        use crate::inflate::{decompress_to_vec_with_stop, TINFLStatus};
+        use crate::stop::StopCheck;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Returns a check that stops after `n` polls.
+        fn stop_after(n: usize) -> StopCheck {
+            let remaining = Arc::new(AtomicUsize::new(n));
+            StopCheck::new(move || {
+                if remaining.load(Ordering::Relaxed) == 0 {
+                    true
+                } else {
+                    remaining.fetch_sub(1, Ordering::Relaxed);
+                    false
+                }
+            })
+        }
+
+        /// Compressible data spanning multiple deflate blocks and many 16 KiB
+        /// poll intervals.
+        fn payload() -> (Vec<u8>, Vec<u8>) {
+            let raw: Vec<u8> = (0..256 * 1024).map(|i| (i % 251) as u8).collect();
+            let compressed = compress_to_vec_zlib(&raw, 6);
+            (raw, compressed)
+        }
+
+        #[test]
+        fn never_stopping_matches_plain_decompress() {
+            let (raw, compressed) = payload();
+            assert_eq!(
+                decompress_to_vec_with_stop(&compressed, true, usize::MAX, &StopCheck::none())
+                    .unwrap(),
+                raw
+            );
+            assert_eq!(
+                decompress_to_vec_with_stop(&compressed, true, usize::MAX, &stop_after(usize::MAX))
+                    .unwrap(),
+                raw
+            );
+        }
+
+        #[test]
+        fn stopping_returns_stopped_status() {
+            let (raw, compressed) = payload();
+            for checks_allowed in [0, 2] {
+                let err = decompress_to_vec_with_stop(
+                    &compressed,
+                    true,
+                    usize::MAX,
+                    &stop_after(checks_allowed),
+                )
+                .unwrap_err();
+                assert_eq!(err.status, TINFLStatus::Stopped);
+                assert!(err.output.len() < raw.len());
+            }
+        }
     }
 }

--- a/miniz_oxide/src/lib.rs
+++ b/miniz_oxide/src/lib.rs
@@ -34,6 +34,8 @@ pub mod inflate;
 #[cfg(feature = "serde")]
 pub mod serde;
 mod shared;
+#[cfg(feature = "with-alloc")]
+pub mod stop;
 
 pub use crate::shared::update_adler32 as mz_adler32_oxide;
 pub use crate::shared::{MZ_ADLER32_INIT, MZ_DEFAULT_WINDOW_BITS};

--- a/miniz_oxide/src/stop.rs
+++ b/miniz_oxide/src/stop.rs
@@ -1,0 +1,68 @@
+//! Optional cooperative cancellation for long-running operations.
+//!
+//! [`StopCheck`] is a single vendored type following the zero-dependency
+//! pattern described in
+//! <https://github.com/imazen/enough/blob/main/ZERO-DEP.md>: a clone-cheap
+//! handle wrapping an optional user closure that is polled at coarse
+//! intervals. [`StopCheck::none()`] costs nothing to poll, so it can be
+//! threaded through internals unconditionally.
+
+use crate::alloc::sync::Arc;
+use core::fmt;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// A clone-cheap cancellation probe polled periodically by long-running
+/// operations.
+///
+/// The closure can capture any cancellation source — an `Arc<AtomicBool>`, a
+/// channel, an async cancellation token, a deadline — so this crate does not
+/// need to know about any of them.
+#[derive(Clone, Default)]
+pub struct StopCheck {
+    inner: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+}
+
+impl StopCheck {
+    /// A check that never stops. Polling it is a single predicted branch and
+    /// constructing it allocates nothing.
+    // Not const: trait objects in const fn need Rust 1.61, above this crate's MSRV.
+    pub fn none() -> StopCheck {
+        StopCheck { inner: None }
+    }
+
+    /// Wraps a closure; the operation stops when it returns true.
+    pub fn new<F>(f: F) -> StopCheck
+    where
+        F: Fn() -> bool + Send + Sync + 'static,
+    {
+        StopCheck {
+            inner: Some(Arc::new(f)),
+        }
+    }
+
+    /// Stops when `flag` becomes true.
+    pub fn from_atomic(flag: Arc<AtomicBool>) -> StopCheck {
+        StopCheck::new(move || flag.load(Ordering::Relaxed))
+    }
+
+    /// Returns true if this check could ever signal a stop.
+    pub fn may_stop(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Polls the underlying source. [`StopCheck::none()`] always returns false.
+    pub fn should_stop(&self) -> bool {
+        match &self.inner {
+            Some(f) => f(),
+            None => false,
+        }
+    }
+}
+
+impl fmt::Debug for StopCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StopCheck")
+            .field("may_stop", &self.may_stop())
+            .finish()
+    }
+}


### PR DESCRIPTION
Follow-up to #193, as a draft — I figured working code might be easier to evaluate than the proposal, but there's no pressure here; feel free to close if it's not a direction you want for the crate.

What it does:

- adds `src/stop.rs`, one self-contained ~70-line type (`StopCheck`) following the zero-dependency pattern from [ZERO-DEP.md](https://github.com/imazen/enough/blob/main/ZERO-DEP.md); no Cargo.toml changes
- `decompress_to_vec_with_stop(input, zlib_header, max_size, &StopCheck)` polls at each deflate block header and roughly every 16 KiB of output in the fast loop, and returns the new `TINFLStatus::Stopped` when the check fires (`DecompressError::output` still carries the partial output)
- `compress_to_vec_with_stop(...)` makes no changes to the compression core at all: it feeds the existing streaming compressor 64 KiB input chunks with `TDEFLFlush::None` and polls between chunks; the output is byte-identical to the one-shot functions (asserted in tests)
- existing entry points are untouched and install no callback

Things you may well want to push back on:

- `TINFLStatus` gains a variant. It's `#[non_exhaustive]` and the C API's `From` impl already has a wildcard arm, so I believe this is additive — but you know the downstream landscape better than I do.
- A pathological all-literal block only gets polled at block boundaries (the interval check sits at the top of the match loop in `decompress_fast`, to stay off the per-symbol path). Match-heavy data — the decompression-bomb case — polls every ≤16 KiB.
- Scope is the one-shot `*_to_vec*` functions only; streaming users already control the loop between calls.
- All names are up for grabs.

Perf, for what one machine is worth (Ryzen 9 7950X, 64 MiB text-like payload at ratio 4x, median of 15 runs): 70.5 ms baseline vs 68.0 / 68.0 / 67.9 ms on this branch for the existing API / `none()` / a live never-firing check. That's inside my run-to-run variance, so I'd call it "no measurable cost" rather than "faster". Happy to share the harness.

If you'd rather not vendor a type at all, there's a sibling branch that takes an optional [`enough`](https://crates.io/crates/enough) dependency instead: [`inflate-stop-enough`](https://github.com/lilith/miniz_oxide/tree/inflate-stop-enough). One caveat I should've stated up front: `enough` is itself MSRV 1.85, so depending on it would raise this crate's MSRV from 1.60 — which is the main reason I'd lean toward the vendored shape for miniz specifically. Either way, or neither — your call.
