### PR TITLE
Fix flags check bug (unreachable) in window_bits_from_flags

### DIFF
--- a/miniz_oxide/src/deflate/core.rs
+++ b/miniz_oxide/src/deflate/core.rs
@@ -2584,7 +2584,7 @@ pub const fn create_comp_flags_from_zip_params(level: i32, window_bits: i32, str
 
 /// Check if the window is
 const fn window_bits_from_flags(flags: u32) -> u8 {
-    if (flags & TDEFL_FORCE_ALL_RAW_BLOCKS & TDEFL_RLE_MATCHES) != 0
+    if (flags & (TDEFL_FORCE_ALL_RAW_BLOCKS | TDEFL_RLE_MATCHES)) != 0
         || (flags & MAX_PROBES_MASK) == 0
     {
         1


### PR DESCRIPTION
Fix the flag bit logic bug in window_bits_from_flags. The bug is unreachable both on master and all the published versions of the library.